### PR TITLE
QBdt in default optimal stack (for single-device environments)

### DIFF
--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -128,6 +128,8 @@ protected:
 
     void ApplySingle(const complex* mtrx, bitLenInt target);
 
+    void Init();
+
 public:
     QBdt(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState = 0,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
@@ -136,15 +138,30 @@ public:
         bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON_F);
 
     QBdt(bitLenInt qBitCount, bitCapInt initState = 0U, qrack_rand_gen_ptr rgp = nullptr,
-        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
+        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = false,
         bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-        real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> ignored = {}, bitLenInt qubitThreshold = 0U,
+        real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {}, bitLenInt qubitThreshold = 0U,
         real1_f separation_thresh = FP_NORM_EPSILON_F)
-        : QBdt({ QINTERFACE_OPTIMAL_SCHROEDINGER }, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase,
-              useHostMem, deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, ignored, qubitThreshold,
-              separation_thresh)
+#if ENABLE_OPENCL
+        : QBdt({ OCLEngine::Instance().GetDeviceCount() ? QINTERFACE_OPENCL : QINTERFACE_CPU }, qBitCount, initState,
+              rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, deviceId, useHardwareRNG, useSparseStateVec,
+              norm_thresh, devList, qubitThreshold, separation_thresh)
+#else
+        : QBdt({ QINTERFACE_CPU }, qBitCount, initState, rgp, phaseFac, doNorm, ignored, useHostMem, deviceId,
+              useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold, separation_thresh)
+#endif
     {
     }
+
+    QBdt(QEnginePtr enginePtr, std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt ignored = 0U,
+        qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
+        bool randomGlobalPhase = false, bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true,
+        bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {},
+        bitLenInt qubitThreshold = 0U, real1_f separation_thresh = FP_NORM_EPSILON_F);
+
+    QEnginePtr ReleaseEngine() { return NODE_TO_QENGINE(root); }
+
+    void LockEngine(QEnginePtr eng) { root = std::make_shared<QBdtQEngineNode>(ONE_CMPLX, eng); }
 
     bool isBinaryDecisionTree() { return true; };
 

--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -190,12 +190,42 @@ public:
     }
     void Decompose(bitLenInt start, QInterfacePtr dest)
     {
-        DecomposeDispose(start, dest->GetQubitCount(), std::dynamic_pointer_cast<QBdt>(dest));
+        QBdtPtr d = std::dynamic_pointer_cast<QBdt>(dest);
+        if (!bdtQubitCount) {
+            d->root = d->MakeQEngineNode(ONE_CMPLX, d->qubitCount, 0U);
+            NODE_TO_QENGINE(root)->Decompose(start, NODE_TO_QENGINE(d->root));
+            d->SetQubitCount(d->qubitCount, d->qubitCount);
+            SetQubitCount(qubitCount - d->qubitCount, qubitCount - d->qubitCount);
+
+            return;
+        }
+
+        DecomposeDispose(start, dest->GetQubitCount(), d);
     }
     QInterfacePtr Decompose(bitLenInt start, bitLenInt length);
-    void Dispose(bitLenInt start, bitLenInt length) { DecomposeDispose(start, length, NULL); }
+    void Dispose(bitLenInt start, bitLenInt length)
+    {
+        if (!bdtQubitCount) {
+            NODE_TO_QENGINE(root)->Dispose(start, length);
+            SetQubitCount(qubitCount - length, qubitCount - length);
 
-    void Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPerm) { DecomposeDispose(start, length, NULL); }
+            return;
+        }
+
+        DecomposeDispose(start, length, NULL);
+    }
+
+    void Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPerm)
+    {
+        if (!bdtQubitCount) {
+            NODE_TO_QENGINE(root)->Dispose(start, length, disposedPerm);
+            SetQubitCount(qubitCount - length, qubitCount - length);
+
+            return;
+        }
+
+        DecomposeDispose(start, length, NULL);
+    }
 
     using QInterface::Allocate;
     bitLenInt Allocate(bitLenInt start, bitLenInt length);

--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -38,6 +38,7 @@ protected:
     bitLenInt bdtQubitCount;
     bitLenInt segmentGlobalQb;
     bitLenInt maxPageQubits;
+    bitLenInt maxQubits;
     int64_t devID;
     QBdtNodeInterfacePtr root;
     bitCapInt bdtMaxQPower;
@@ -117,16 +118,16 @@ protected:
 
     void ResetStateVector(bitLenInt aqb = 0U)
     {
-        if (!bdtQubitCount) {
+        if (attachedQubitCount <= aqb) {
             return;
         }
 
-        if (attachedQubitCount) {
-            throw std::domain_error("QBdt::ResetStateVector() not implemented when already partially BDT qubits!");
+        if (bdtQubitCount) {
+            throw std::domain_error("Cannot QBdt::ResetStateVector() with BDT qubits!");
         }
 
         QBdtQEngineNodePtr oRoot = std::dynamic_pointer_cast<QBdtQEngineNode>(root);
-        SetQubitCount(qubitCount, aqb);
+        SetQubitCount(qubitCount, 0U);
         SetQuantumState(NODE_TO_QENGINE(oRoot));
     }
 

--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -59,10 +59,6 @@ protected:
 
     QBdtQEngineNodePtr MakeQEngineNode(complex scale, bitLenInt qbCount, bitCapInt perm = 0U);
 
-    void FallbackMtrx(const complex* mtrx, bitLenInt target);
-    void FallbackMCMtrx(
-        const complex* mtrx, const bitLenInt* controls, bitLenInt controlLen, bitLenInt target, bool isAnti);
-
     QInterfacePtr MakeTempStateVector()
     {
         QInterfacePtr copyPtr = NODE_TO_QENGINE(MakeQEngineNode(ONE_R1, qubitCount));

--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -139,7 +139,7 @@ public:
         bitLenInt qubitThreshold = 0, real1_f separation_thresh = FP_NORM_EPSILON_F);
 
     QBdt(bitLenInt qBitCount, bitCapInt initState = 0U, qrack_rand_gen_ptr rgp = nullptr,
-        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = false,
+        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
         bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {}, bitLenInt qubitThreshold = 0U,
         real1_f separation_thresh = FP_NORM_EPSILON_F)
@@ -156,7 +156,7 @@ public:
 
     QBdt(QEnginePtr enginePtr, std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt ignored = 0U,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
-        bool randomGlobalPhase = false, bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true,
+        bool randomGlobalPhase = true, bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true,
         bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {},
         bitLenInt qubitThreshold = 0U, real1_f separation_thresh = FP_NORM_EPSILON_F);
 

--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -34,7 +34,6 @@ class QBdt : public QAlu, public QParity, public QInterface {
 class QBdt : public QParity, public QInterface {
 #endif
 protected:
-    bool isAttached;
     bitLenInt attachedQubitCount;
     bitLenInt bdtQubitCount;
     bitLenInt segmentGlobalQb;
@@ -79,7 +78,7 @@ protected:
             return;
         }
 
-        if (isAttached) {
+        if (attachedQubitCount) {
             throw std::domain_error("QBdt::SetStateVector() not yet implemented, after Attach() call!");
         }
 

--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -188,20 +188,6 @@ public:
     {
         return Compose(std::dynamic_pointer_cast<QBdt>(toCopy), start);
     }
-    bitLenInt Attach(QEnginePtr toCopy, bitLenInt start)
-    {
-        if (start == qubitCount) {
-            return Attach(toCopy);
-        }
-
-        const bitLenInt origSize = qubitCount;
-        ROL(origSize - start, 0U, qubitCount);
-        bitLenInt result = Attach(toCopy, qubitCount);
-        ROR(origSize - start, 0U, qubitCount);
-
-        return result;
-    }
-    bitLenInt Attach(QEnginePtr toCopy);
     void Decompose(bitLenInt start, QInterfacePtr dest)
     {
         DecomposeDispose(start, dest->GetQubitCount(), std::dynamic_pointer_cast<QBdt>(dest));

--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -115,6 +115,21 @@ protected:
 
     void Init();
 
+    void ResetStateVector(bitLenInt aqb = 0U)
+    {
+        if (!bdtQubitCount) {
+            return;
+        }
+
+        if (attachedQubitCount) {
+            throw std::domain_error("QBdt::ResetStateVector() not implemented when already partially BDT qubits!");
+        }
+
+        QBdtQEngineNodePtr oRoot = std::dynamic_pointer_cast<QBdtQEngineNode>(root);
+        SetQubitCount(qubitCount, aqb);
+        SetQuantumState(NODE_TO_QENGINE(oRoot));
+    }
+
 public:
     QBdt(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState = 0,
         qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
@@ -144,7 +159,14 @@ public:
         bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {},
         bitLenInt qubitThreshold = 0U, real1_f separation_thresh = FP_NORM_EPSILON_F);
 
-    QEnginePtr ReleaseEngine() { return NODE_TO_QENGINE(root); }
+    QEnginePtr ReleaseEngine()
+    {
+        if (bdtQubitCount) {
+            throw std::domain_error("Cannot release QEngine from QBdt with BDT qubits!");
+        }
+
+        return NODE_TO_QENGINE(root);
+    }
 
     void LockEngine(QEnginePtr eng) { root = std::make_shared<QBdtQEngineNode>(ONE_CMPLX, eng); }
 

--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -37,6 +37,8 @@ protected:
     bool isAttached;
     bitLenInt attachedQubitCount;
     bitLenInt bdtQubitCount;
+    bitLenInt segmentGlobalQb;
+    bitLenInt maxPageQubits;
     int64_t devID;
     QBdtNodeInterfacePtr root;
     bitCapInt bdtMaxQPower;

--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -88,16 +88,6 @@ protected:
         root = nRoot;
         SetQubitCount(qubitCount, qubitCount);
     }
-    void ResetStateVector()
-    {
-        if (bdtQubitCount) {
-            return;
-        }
-
-        QBdtQEngineNodePtr oRoot = std::dynamic_pointer_cast<QBdtQEngineNode>(root);
-        SetQubitCount(qubitCount, 0U);
-        SetQuantumState(NODE_TO_QENGINE(oRoot));
-    }
 
     template <typename Fn> void GetTraversal(Fn getLambda);
     template <typename Fn> void SetTraversal(Fn setLambda);
@@ -346,14 +336,12 @@ public:
     {
         ExecuteAsStateVector(
             [&](QInterfacePtr eng) { QINTERFACE_TO_QALU(eng)->PhaseFlipIfLess(greaterPerm, start, length); });
-        ResetStateVector();
     }
     void CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length, bitLenInt flagIndex)
     {
         ExecuteAsStateVector([&](QInterfacePtr eng) {
             QINTERFACE_TO_QALU(eng)->CPhaseFlipIfLess(greaterPerm, start, length, flagIndex);
         });
-        ResetStateVector();
     }
     void INCDECSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex)
     {

--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -147,7 +147,7 @@ public:
               rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, deviceId, useHardwareRNG, useSparseStateVec,
               norm_thresh, devList, qubitThreshold, separation_thresh)
 #else
-        : QBdt({ QINTERFACE_CPU }, qBitCount, initState, rgp, phaseFac, doNorm, ignored, useHostMem, deviceId,
+        : QBdt({ QINTERFACE_CPU }, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem, deviceId,
               useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold, separation_thresh)
 #endif
     {

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -27,8 +27,13 @@ typedef std::shared_ptr<QStabilizerHybrid> QStabilizerHybridPtr;
  * A "Qrack::QStabilizerHybrid" internally switched between Qrack::QStabilizer and Qrack::QEngine to maximize
  * performance.
  */
-class QStabilizerHybrid : public QEngine {
+#if ENABLE_ALU
+class QStabilizerHybrid : public QAlu, public QParity, public QInterface {
+#else
+class QStabilizerHybrid : public QParity, public QInterface {
+#endif
 protected:
+    bool useHostRam;
     bool isDefaultPaging;
     bool doNormalize;
     bool isSparse;
@@ -40,7 +45,7 @@ protected:
     real1_f separabilityThreshold;
     int64_t devID;
     complex phaseFactor;
-    QEnginePtr engine;
+    QInterfacePtr engine;
     QStabilizerPtr stabilizer;
     std::vector<int64_t> deviceIDs;
     std::vector<QInterfaceEngine> engineTypes;
@@ -48,8 +53,8 @@ protected:
     std::vector<MpsShardPtr> shards;
 
     QStabilizerPtr MakeStabilizer(bitCapInt perm = 0U);
-    QEnginePtr MakeEngine(bitCapInt perm = 0U);
-    QEnginePtr MakeEngine(bitCapInt perm, bitLenInt qbCount);
+    QInterfacePtr MakeEngine(bitCapInt perm = 0U);
+    QInterfacePtr MakeEngine(bitCapInt perm, bitLenInt qbCount);
 
     void InvertBuffer(bitLenInt qubit);
     void FlushH(bitLenInt qubit);
@@ -163,9 +168,9 @@ public:
             return;
         }
         if (engine) {
-            engine = std::make_shared<QPager>(engine, engineTypes, qubitCount, 0U, rand_generator, phaseFactor,
-                doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse, (real1_f)amplitudeFloor,
-                deviceIDs, thresholdQubits, separabilityThreshold);
+            engine = std::make_shared<QPager>(std::dynamic_pointer_cast<QEngine>(engine), engineTypes, qubitCount, 0U,
+                rand_generator, phaseFactor, doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse,
+                (real1_f)amplitudeFloor, deviceIDs, thresholdQubits, separabilityThreshold);
         }
         engineTypes.insert(engineTypes.begin(), QINTERFACE_QPAGER);
     }
@@ -248,128 +253,6 @@ public:
         }
     }
 
-    void ZeroAmplitudes()
-    {
-        SwitchToEngine();
-        engine->ZeroAmplitudes();
-    }
-    void CopyStateVec(QEnginePtr src) { CopyStateVec(std::dynamic_pointer_cast<QStabilizerHybrid>(src)); }
-    void CopyStateVec(QStabilizerHybridPtr src)
-    {
-        SetPermutation(0U);
-
-        if (src->stabilizer) {
-            stabilizer = std::dynamic_pointer_cast<QStabilizer>(src->stabilizer->Clone());
-            for (bitLenInt i = 0U; i < qubitCount; ++i) {
-                if (src->shards[i]) {
-                    shards[i] = std::make_shared<MpsShard>(src->shards[i]->gate);
-                }
-            }
-            return;
-        }
-
-        engine = MakeEngine();
-        engine->CopyStateVec(src->engine);
-    }
-    bool IsZeroAmplitude()
-    {
-        if (stabilizer) {
-            return false;
-        }
-
-        return engine->IsZeroAmplitude();
-    }
-    void GetAmplitudePage(complex* pagePtr, bitCapIntOcl offset, bitCapIntOcl length)
-    {
-        SwitchToEngine();
-        engine->GetAmplitudePage(pagePtr, offset, length);
-    }
-    void SetAmplitudePage(const complex* pagePtr, bitCapIntOcl offset, bitCapIntOcl length)
-    {
-        SwitchToEngine();
-        engine->SetAmplitudePage(pagePtr, offset, length);
-    }
-    void SetAmplitudePage(QEnginePtr pageEnginePtr, bitCapIntOcl srcOffset, bitCapIntOcl dstOffset, bitCapIntOcl length)
-    {
-        SetAmplitudePage(std::dynamic_pointer_cast<QStabilizerHybrid>(pageEnginePtr), srcOffset, dstOffset, length);
-    }
-    void SetAmplitudePage(
-        QStabilizerHybridPtr pageEnginePtr, bitCapIntOcl srcOffset, bitCapIntOcl dstOffset, bitCapIntOcl length)
-    {
-        SwitchToEngine();
-        pageEnginePtr->SwitchToEngine();
-        engine->SetAmplitudePage(pageEnginePtr->engine, srcOffset, dstOffset, length);
-    }
-    void ShuffleBuffers(QEnginePtr oEngine) { ShuffleBuffers(std::dynamic_pointer_cast<QStabilizerHybrid>(oEngine)); }
-    void ShuffleBuffers(QStabilizerHybridPtr oEngine)
-    {
-        SwitchToEngine();
-        oEngine->SwitchToEngine();
-        engine->ShuffleBuffers(oEngine->engine);
-    }
-    QEnginePtr CloneEmpty();
-    void QueueSetDoNormalize(bool doNorm)
-    {
-        doNormalize = doNorm;
-        if (engine) {
-            engine->QueueSetDoNormalize(doNorm);
-        }
-    }
-    void QueueSetRunningNorm(real1_f runningNrm)
-    {
-        if (engine) {
-            engine->QueueSetRunningNorm(runningNrm);
-        }
-    }
-    real1_f ProbReg(bitLenInt start, bitLenInt length, bitCapInt permutation)
-    {
-        QStabilizerHybridPtr thisClone = stabilizer ? std::dynamic_pointer_cast<QStabilizerHybrid>(Clone()) : NULL;
-        if (thisClone) {
-            thisClone->SwitchToEngine();
-        }
-        QInterfacePtr thisEngine = thisClone ? thisClone->engine : engine;
-        return thisEngine->ProbReg(start, length, permutation);
-    }
-    using QEngine::ApplyM;
-    void ApplyM(bitCapInt regMask, bitCapInt result, complex nrm)
-    {
-        SwitchToEngine();
-        return engine->ApplyM(regMask, result, nrm);
-    }
-    real1_f GetExpectation(bitLenInt valueStart, bitLenInt valueLength)
-    {
-        QStabilizerHybridPtr thisClone = stabilizer ? std::dynamic_pointer_cast<QStabilizerHybrid>(Clone()) : NULL;
-        if (thisClone) {
-            thisClone->SwitchToEngine();
-        }
-        QEnginePtr thisEngine = thisClone ? thisClone->engine : engine;
-        return thisEngine->GetExpectation(valueStart, valueLength);
-    }
-    void Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const complex* mtrx, bitLenInt bitCount,
-        const bitCapIntOcl* qPowersSorted, bool doCalcNorm, real1_f norm_thresh = REAL1_DEFAULT_ARG)
-    {
-        SwitchToEngine();
-        engine->Apply2x2(offset1, offset2, mtrx, bitCount, qPowersSorted, doCalcNorm, norm_thresh);
-    }
-    real1_f GetRunningNorm()
-    {
-        if (stabilizer) {
-            return (real1_f)ONE_R1;
-        }
-
-        Finish();
-        return engine->GetRunningNorm();
-    }
-
-    real1_f FirstNonzeroPhase()
-    {
-        if (stabilizer) {
-            return stabilizer->FirstNonzeroPhase();
-        }
-
-        return engine->FirstNonzeroPhase();
-    }
-
     /**
      * Switches between CPU and GPU used modes. (This will not incur a performance penalty, if the chosen mode matches
      * the current mode.) Mode switching happens automatically when qubit counts change, but Compose() and Decompose()
@@ -383,7 +266,7 @@ public:
 
     bool isBinaryDecisionTree() { return engine && engine->isBinaryDecisionTree(); };
 
-    using QEngine::Compose;
+    using QInterface::Compose;
     bitLenInt Compose(QStabilizerHybridPtr toCopy);
     bitLenInt Compose(QInterfacePtr toCopy) { return Compose(std::dynamic_pointer_cast<QStabilizerHybrid>(toCopy)); }
     bitLenInt Compose(QStabilizerHybridPtr toCopy, bitLenInt start);
@@ -399,7 +282,7 @@ public:
     QInterfacePtr Decompose(bitLenInt start, bitLenInt length);
     void Dispose(bitLenInt start, bitLenInt length);
     void Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPerm);
-    using QEngine::Allocate;
+    using QInterface::Allocate;
     bitLenInt Allocate(bitLenInt start, bitLenInt length);
 
     void GetQuantumState(complex* outputState);
@@ -461,7 +344,7 @@ public:
     void MACInvert(
         const bitLenInt* controls, bitLenInt controlLen, complex topRight, complex bottomLeft, bitLenInt target);
 
-    using QEngine::UniformlyControlledSingleBit;
+    using QInterface::UniformlyControlledSingleBit;
     void UniformlyControlledSingleBit(
         const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubitIndex, const complex* mtrxs)
     {
@@ -638,6 +521,10 @@ public:
     }
 
 #if ENABLE_ALU
+    using QInterface::M;
+    bool M(bitLenInt q) { return QInterface::M(q); }
+    using QInterface::X;
+    void X(bitLenInt q) { QInterface::X(q); }
     void CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length, bitLenInt flagIndex)
     {
         SwitchToEngine();
@@ -657,6 +544,24 @@ public:
         }
 
         engine->INC(toAdd, start, length);
+    }
+    void DEC(bitCapInt toSub, bitLenInt start, bitLenInt length)
+    {
+        if (stabilizer) {
+            QInterface::DEC(toSub, start, length);
+            return;
+        }
+
+        engine->DEC(toSub, start, length);
+    }
+    void DECS(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt overflowIndex)
+    {
+        if (stabilizer) {
+            QInterface::DECS(toSub, start, length, overflowIndex);
+            return;
+        }
+
+        engine->DECS(toSub, start, length, overflowIndex);
     }
     void CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const bitLenInt* controls, bitLenInt controlLen)
     {

--- a/src/qbdt/node_interface.cpp
+++ b/src/qbdt/node_interface.cpp
@@ -112,7 +112,7 @@ void QBdtNodeInterface::_par_for_qbdt(const bitCapInt begin, const bitCapInt end
 
 QBdtNodeInterfacePtr QBdtNodeInterface::RemoveSeparableAtDepth(bitLenInt depth, const bitLenInt& size)
 {
-    if (norm(scale) <= FP_NORM_EPSILON) {
+    if (!size || (norm(scale) <= FP_NORM_EPSILON)) {
         return NULL;
     }
 
@@ -138,13 +138,6 @@ QBdtNodeInterfacePtr QBdtNodeInterface::RemoveSeparableAtDepth(bitLenInt depth, 
 
     QBdtNodeInterfacePtr toRet = ShallowClone();
     toRet->scale /= abs(toRet->scale);
-
-    if (!size) {
-        branches[0U] = NULL;
-        branches[1U] = NULL;
-
-        return toRet;
-    }
 
     QBdtNodeInterfacePtr temp = toRet->RemoveSeparableAtDepth(size, 0);
 

--- a/src/qbdt/node_interface.cpp
+++ b/src/qbdt/node_interface.cpp
@@ -112,7 +112,7 @@ void QBdtNodeInterface::_par_for_qbdt(const bitCapInt begin, const bitCapInt end
 
 QBdtNodeInterfacePtr QBdtNodeInterface::RemoveSeparableAtDepth(bitLenInt depth, const bitLenInt& size)
 {
-    if (!size || (norm(scale) <= FP_NORM_EPSILON)) {
+    if (norm(scale) <= FP_NORM_EPSILON) {
         return NULL;
     }
 
@@ -134,6 +134,10 @@ QBdtNodeInterfacePtr QBdtNodeInterface::RemoveSeparableAtDepth(bitLenInt depth, 
         }
 
         return toRet;
+    }
+
+    if (!size) {
+        return NULL;
     }
 
     QBdtNodeInterfacePtr toRet = ShallowClone();

--- a/src/qbdt/qengine_node.cpp
+++ b/src/qbdt/qengine_node.cpp
@@ -130,12 +130,8 @@ void QBdtQEngineNode::InsertAtDepth(QBdtNodeInterfacePtr b, bitLenInt depth, con
         return;
     }
 
-    if (depth) {
-        throw std::runtime_error("QBdtQEngineNode::InsertAtDepth() not implemented for nonzero depth!");
-    }
-
     QBdtQEngineNodePtr bEng = std::dynamic_pointer_cast<QBdtQEngineNode>(b);
-    qReg->Compose(bEng->qReg, 0U);
+    qReg->Compose(bEng->qReg, depth);
 }
 
 QBdtNodeInterfacePtr QBdtQEngineNode::RemoveSeparableAtDepth(bitLenInt depth, const bitLenInt& size)

--- a/src/qbdt/qengine_node.cpp
+++ b/src/qbdt/qengine_node.cpp
@@ -140,7 +140,7 @@ void QBdtQEngineNode::InsertAtDepth(QBdtNodeInterfacePtr b, bitLenInt depth, con
 
 QBdtNodeInterfacePtr QBdtQEngineNode::RemoveSeparableAtDepth(bitLenInt depth, const bitLenInt& size)
 {
-    if (!size || (IS_NORM_0(scale))) {
+    if (!size || IS_NORM_0(scale)) {
         return NULL;
     }
 

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -291,6 +291,10 @@ complex QBdt::GetAmplitude(bitCapInt perm)
 
 bitLenInt QBdt::Compose(QBdtPtr toCopy, bitLenInt start)
 {
+    if (maxPageQubits < (attachedQubitCount + toCopy->attachedQubitCount)) {
+        toCopy->ResetStateVector((attachedQubitCount + toCopy->attachedQubitCount) - maxPageQubits);
+    }
+
     if (!bdtQubitCount && !toCopy->bdtQubitCount) {
         NODE_TO_QENGINE(root)->Compose(NODE_TO_QENGINE(toCopy->root), start);
         SetQubitCount(qubitCount + toCopy->qubitCount, qubitCount + toCopy->qubitCount);
@@ -336,6 +340,14 @@ QInterfacePtr QBdt::Decompose(bitLenInt start, bitLenInt length)
 
 void QBdt::DecomposeDispose(bitLenInt start, bitLenInt length, QBdtPtr dest)
 {
+    if (start && bdtQubitCount && attachedQubitCount) {
+        ROR(start, 0U, qubitCount);
+        DecomposeDispose(0U, length, dest);
+        ROL(start, 0U, qubitCount);
+
+        return;
+    }
+
     bitLenInt attachedDiff = 0U;
     if ((start + length) > bdtQubitCount) {
         attachedDiff = (start > bdtQubitCount) ? length : (start + length - bdtQubitCount);

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -291,7 +291,7 @@ complex QBdt::GetAmplitude(bitCapInt perm)
 
 bitLenInt QBdt::Compose(QBdtPtr toCopy, bitLenInt start)
 {
-    if (attachedQubitCount || toCopy->attachedQubitCount) {
+    if (bdtQubitCount && (attachedQubitCount || toCopy->attachedQubitCount)) {
         if (start < bdtQubitCount) {
             const bitLenInt offset = bdtQubitCount - start;
             ROR(qubitCount - offset, 0U, qubitCount);
@@ -329,7 +329,6 @@ QInterfacePtr QBdt::Decompose(bitLenInt start, bitLenInt length)
 
 void QBdt::DecomposeDispose(bitLenInt start, bitLenInt length, QBdtPtr dest)
 {
-
     bitLenInt attachedDiff = 0U;
     if ((start + length) > bdtQubitCount) {
         attachedDiff = (start > bdtQubitCount) ? length : (start + length - bdtQubitCount);

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -282,38 +282,15 @@ real1_f QBdt::SumSqrDiff(QBdtPtr toCompare)
         return ONE_R1_F;
     }
 
-    // TODO: Fix this method, without the reset:
-    // ResetStateVector();
-    // toCompare->ResetStateVector();
+    if (randGlobalPhase) {
+        real1_f lPhaseArg = FirstNonzeroPhase();
+        real1_f rPhaseArg = toCompare->FirstNonzeroPhase();
+        root->scale *= std::polar(ONE_R1, rPhaseArg - lPhaseArg);
+    }
 
     complex projection = ZERO_CMPLX;
     for (bitCapInt i = 0U; i < maxQPower; ++i) {
-        QBdtNodeInterfacePtr leaf1 = root;
-        QBdtNodeInterfacePtr leaf2 = toCompare->root;
-        complex scale1 = leaf1->scale;
-        complex scale2 = leaf2->scale;
-        bitLenInt j;
-        for (j = 0U; j < qubitCount; ++j) {
-            if (IS_NORM_0(scale1)) {
-                break;
-            }
-            leaf1 = leaf1->branches[SelectBit(i, j)];
-            scale1 *= leaf1->scale;
-        }
-        if (j < qubitCount) {
-            continue;
-        }
-        for (j = 0U; j < qubitCount; ++j) {
-            if (IS_NORM_0(scale2)) {
-                break;
-            }
-            leaf2 = leaf2->branches[SelectBit(i, j)];
-            scale2 *= leaf2->scale;
-        }
-        if (j < qubitCount) {
-            continue;
-        }
-        projection += conj(scale2) * scale1;
+        projection += conj(toCompare->GetAmplitude(i)) * GetAmplitude(i);
     }
 
     return ONE_R1_F - clampProb((real1_f)norm(projection));

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -291,6 +291,13 @@ complex QBdt::GetAmplitude(bitCapInt perm)
 
 bitLenInt QBdt::Compose(QBdtPtr toCopy, bitLenInt start)
 {
+    if (!bdtQubitCount && !toCopy->bdtQubitCount) {
+        NODE_TO_QENGINE(root)->Compose(NODE_TO_QENGINE(toCopy->root), start);
+        SetQubitCount(qubitCount + toCopy->qubitCount, qubitCount + toCopy->qubitCount);
+
+        return start;
+    }
+
     if (bdtQubitCount && (attachedQubitCount || toCopy->attachedQubitCount)) {
         if (start < bdtQubitCount) {
             const bitLenInt offset = bdtQubitCount - start;

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -180,8 +180,6 @@ QInterfacePtr QBdt::Clone()
     QBdtPtr copyPtr = std::make_shared<QBdt>(qubitCount, 0U, rand_generator, ONE_CMPLX, doNormalize, randGlobalPhase,
         false, -1, (hardware_rand_generator == NULL) ? false : true, false, (real1_f)amplitudeFloor);
 
-    ResetStateVector();
-
     copyPtr->root = root ? root->ShallowClone() : NULL;
     copyPtr->SetQubitCount(qubitCount, attachedQubitCount);
     copyPtr->isAttached = isAttached;
@@ -284,8 +282,9 @@ real1_f QBdt::SumSqrDiff(QBdtPtr toCompare)
         return ONE_R1_F;
     }
 
-    ResetStateVector();
-    toCompare->ResetStateVector();
+    // TODO: Fix this method, without the reset:
+    // ResetStateVector();
+    // toCompare->ResetStateVector();
 
     complex projection = ZERO_CMPLX;
     for (bitCapInt i = 0U; i < maxQPower; ++i) {
@@ -341,13 +340,6 @@ complex QBdt::GetAmplitude(bitCapInt perm)
 
 bitLenInt QBdt::Compose(QBdtPtr toCopy, bitLenInt start)
 {
-    ResetStateVector();
-    toCopy->ResetStateVector();
-
-    if (toCopy->attachedQubitCount) {
-        throw std::domain_error("QBdt::Compose() not fully implemented, after Attach()!");
-    }
-
     if (attachedQubitCount && start) {
         ROR(start, 0U, qubitCount);
         Compose(toCopy, 0U);
@@ -449,11 +441,6 @@ QInterfacePtr QBdt::Decompose(bitLenInt start, bitLenInt length)
 
 void QBdt::DecomposeDispose(bitLenInt start, bitLenInt length, QBdtPtr dest)
 {
-    ResetStateVector();
-
-    if (length > bdtQubitCount) {
-        throw std::domain_error("QBdt::DecomposeDispose() not fully implemented, after Attach()!");
-    }
 
     if (attachedQubitCount && start) {
         ROR(start, 0U, qubitCount);
@@ -464,7 +451,6 @@ void QBdt::DecomposeDispose(bitLenInt start, bitLenInt length, QBdtPtr dest)
     }
 
     if (dest) {
-        dest->ResetStateVector();
         dest->root = root->RemoveSeparableAtDepth(start, length);
     } else {
         root->RemoveSeparableAtDepth(start, length);

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -26,14 +26,12 @@ QBdt::QBdt(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt ini
     : QInterface(qBitCount, rgp, doNorm, useHardwareRNG, randomGlobalPhase, doNorm ? norm_thresh : ZERO_R1_F)
     , devID(deviceId)
     , root(NULL)
-    , bdtMaxQPower(pow2(qBitCount))
     , deviceIDs(devIds)
     , engines(eng)
 {
     Init();
 
-    bdtQubitCount = (maxPageQubits < qBitCount) ? (qBitCount - maxPageQubits) : 0U;
-    attachedQubitCount = qBitCount - bdtQubitCount;
+    SetQubitCount(qBitCount, (maxPageQubits < qBitCount) ? maxPageQubits : qBitCount);
 
     SetPermutation(initState);
 }
@@ -45,14 +43,12 @@ QBdt::QBdt(QEnginePtr enginePtr, std::vector<QInterfaceEngine> eng, bitLenInt qB
     : QInterface(qBitCount, rgp, doNorm, useHardwareRNG, randomGlobalPhase, doNorm ? norm_thresh : ZERO_R1_F)
     , devID(deviceId)
     , root(NULL)
-    , bdtMaxQPower(pow2(qBitCount))
     , deviceIDs(devIds)
     , engines(eng)
 {
     Init();
 
-    bdtQubitCount = 0U;
-    attachedQubitCount = qBitCount;
+    SetQubitCount(qBitCount, qBitCount);
 
     LockEngine(enginePtr);
 }
@@ -163,7 +159,7 @@ QInterfacePtr QBdt::Clone()
 
 template <typename Fn> void QBdt::GetTraversal(Fn getLambda)
 {
-    for (bitCapInt i = 0U; i < bdtMaxQPower; ++i) {
+    for (bitCapInt i = 0U; i < maxQPower; ++i) {
         QBdtNodeInterfacePtr leaf = root;
         complex scale = leaf->scale;
         for (bitLenInt j = 0U; j < bdtQubitCount; ++j) {
@@ -185,7 +181,7 @@ template <typename Fn> void QBdt::SetTraversal(Fn setLambda)
 {
     root = std::make_shared<QBdtNode>();
 
-    for (bitCapInt i = 0U; i < bdtMaxQPower; ++i) {
+    for (bitCapInt i = 0U; i < maxQPower; ++i) {
         QBdtNodeInterfacePtr leaf = root;
         for (bitLenInt j = 0U; j < bdtQubitCount; ++j) {
             leaf->Branch();

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -305,6 +305,9 @@ bitLenInt QBdt::Compose(QBdtPtr toCopy, bitLenInt start)
 
         if (maxPageQubits < (attachedQubitCount + toCopy->attachedQubitCount + qbSpan)) {
             const bitLenInt diff = (attachedQubitCount + toCopy->attachedQubitCount + qbSpan) - maxPageQubits;
+            if (toCopy->qubitCount < diff) {
+                throw std::domain_error("Too many attached qubits to compose in QBdt::Compose()!");
+            }
             toCopy->ResetStateVector(toCopy->qubitCount - diff);
         }
     }

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -146,11 +146,15 @@ QInterfacePtr QBdt::Clone()
         return copyPtr;
     }
 
-    copyPtr->SetTraversal([](bitCapIntOcl i, QBdtNodeInterfacePtr leaf) {
-        QBdtQEngineNodePtr eLeaf = std::dynamic_pointer_cast<QBdtQEngineNode>(leaf);
-        if (eLeaf->qReg) {
-            eLeaf->qReg = std::dynamic_pointer_cast<QEngine>(eLeaf->qReg->Clone());
+    std::map<QEnginePtr, QEnginePtr> qis;
+
+    copyPtr->SetTraversal([&qis](bitCapIntOcl i, QBdtNodeInterfacePtr leaf) {
+        QBdtQEngineNodePtr qenp = std::dynamic_pointer_cast<QBdtQEngineNode>(leaf);
+        QEnginePtr qi = NODE_TO_QENGINE(qenp);
+        if (qis.find(qi) == qis.end()) {
+            qis[qi] = std::dynamic_pointer_cast<QEngine>(qi->Clone());
         }
+        NODE_TO_QENGINE(qenp) = qis[qi];
     });
     copyPtr->root->Prune(bdtQubitCount);
 

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -914,22 +914,22 @@ void QBdt::MCInvert(
     }
 
     const complex mtrx[4U] = { ZERO_CMPLX, topRight, bottomLeft, ZERO_CMPLX };
-    if ((controlLen > 1U) || !IS_NORM_0(ONE_CMPLX - topRight) || !IS_NORM_0(ONE_CMPLX - bottomLeft)) {
+    if (!IS_NORM_0(ONE_CMPLX - topRight) || !IS_NORM_0(ONE_CMPLX - bottomLeft)) {
         ApplyControlledSingle(mtrx, controls, controlLen, target, false);
         return;
     }
 
-    std::vector<bitLenInt> controlVec(controlLen);
-    std::copy(controls, controls + controlLen, controlVec.begin());
-    std::sort(controlVec.begin(), controlVec.end());
+    std::unique_ptr<bitLenInt[]> lControls = std::unique_ptr<bitLenInt[]>(new bitLenInt[controlLen]);
+    std::copy(controls, controls + controlLen, lControls.get());
+    std::sort(lControls.get(), lControls.get() + controlLen);
 
-    if ((controlVec.back() < target) || (target >= bdtQubitCount)) {
+    if ((lControls.get()[controlLen - 1U] < target) || (target >= bdtQubitCount)) {
         ApplyControlledSingle(mtrx, controls, controlLen, target, false);
         return;
     }
 
     H(target);
-    MCPhase(controls, controlLen, ONE_CMPLX, -ONE_CMPLX, target);
+    MCPhase(lControls.get(), controlLen, ONE_CMPLX, -ONE_CMPLX, target);
     H(target);
 }
 } // namespace Qrack

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -291,18 +291,28 @@ complex QBdt::GetAmplitude(bitCapInt perm)
 
 bitLenInt QBdt::Compose(QBdtPtr toCopy, bitLenInt start)
 {
-    if (attachedQubitCount && start) {
-        ROR(start, 0U, qubitCount);
-        Compose(toCopy, 0U);
-        ROL(start, 0U, qubitCount);
+    if (attachedQubitCount || toCopy->attachedQubitCount) {
+        if (start < bdtQubitCount) {
+            const bitLenInt offset = bdtQubitCount - start;
+            ROR(qubitCount - offset, 0U, qubitCount);
+            Compose(toCopy, offset);
+            ROL(qubitCount - offset, 0U, qubitCount);
 
-        return start;
+            return start;
+        }
+
+        if (start > bdtQubitCount) {
+            const bitLenInt offset = start - bdtQubitCount;
+            ROR(offset, 0U, qubitCount);
+            Compose(toCopy, qubitCount - offset);
+            ROL(offset, 0U, qubitCount);
+
+            return start;
+        }
     }
 
-    root->InsertAtDepth(toCopy->root, start, toCopy->bdtQubitCount);
+    root->InsertAtDepth(toCopy->root, start, toCopy->qubitCount);
     SetQubitCount(qubitCount + toCopy->qubitCount, attachedQubitCount + toCopy->attachedQubitCount);
-    bdtQubitCount = (maxPageQubits < qubitCount) ? (qubitCount - maxPageQubits) : 0U;
-    attachedQubitCount = qubitCount - bdtQubitCount;
 
     return start;
 }

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -61,7 +61,7 @@ QStabilizerHybrid::QStabilizerHybrid(std::vector<QInterfaceEngine> eng, bitLenIn
         maxPageQubits = log2(devContext->GetMaxAlloc() / sizeof(complex));
         maxQubitPlusAncillaCount = maxPageQubits + 2U;
         if (qubitCount > maxPageQubits) {
-            if (getenv("QRACK_QPAGER_DEVICES")) {
+            if (devList.size() || getenv("QRACK_QPAGER_DEVICES")) {
                 engineTypes.push_back(QINTERFACE_QPAGER);
             } else {
                 engineTypes.push_back(QINTERFACE_BDT);

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -61,7 +61,11 @@ QStabilizerHybrid::QStabilizerHybrid(std::vector<QInterfaceEngine> eng, bitLenIn
         maxPageQubits = log2(devContext->GetMaxAlloc() / sizeof(complex));
         maxQubitPlusAncillaCount = maxPageQubits + 2U;
         if (qubitCount > maxPageQubits) {
-            engineTypes.push_back(QINTERFACE_QPAGER);
+            if (getenv("QRACK_QPAGER_DEVICES")) {
+                engineTypes.push_back(QINTERFACE_QPAGER);
+            } else {
+                engineTypes.push_back(QINTERFACE_BDT);
+            }
         }
     }
 #endif

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -331,9 +331,6 @@ QInterfacePtr QStabilizerHybrid::Clone()
         phaseFactor, doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse, (real1_f)amplitudeFloor,
         std::vector<int64_t>{}, thresholdQubits, separabilityThreshold);
 
-    Finish();
-    c->Finish();
-
     if (engine) {
         // Clone and set engine directly.
         c->engine = std::dynamic_pointer_cast<QEngine>(engine->Clone());

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -58,7 +58,7 @@ QStabilizerHybrid::QStabilizerHybrid(std::vector<QInterfaceEngine> eng, bitLenIn
 #if ENABLE_OPENCL
     if ((engineTypes.size() == 1U) && (engineTypes[0U] == QINTERFACE_OPTIMAL_BASE)) {
         isDefaultPaging = true;
-        isPagingVsBdt = devList.size() || getenv("QRACK_QPAGER_DEVICES");
+        isPagingVsBdt = devList.size() || !getenv("QRACK_QBDT_DEFAULT_OPT_IN") || getenv("QRACK_QPAGER_DEVICES");
 
         DeviceContextPtr devContext = OCLEngine::Instance().GetDeviceContextPtr(devID);
         maxPageQubits = log2(devContext->GetMaxAlloc() / sizeof(complex));

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -38,6 +38,7 @@ QStabilizerHybrid::QStabilizerHybrid(std::vector<QInterfaceEngine> eng, bitLenIn
     : QInterface(qBitCount, rgp, doNorm, useHardwareRNG, randomGlobalPhase, doNorm ? norm_thresh : ZERO_R1_F)
     , useHostRam(useHostMem)
     , isDefaultPaging(false)
+    , isPagingVsBdt(false)
     , doNormalize(doNorm)
     , isSparse(useSparseStateVec)
     , useTGadget(true)
@@ -57,12 +58,13 @@ QStabilizerHybrid::QStabilizerHybrid(std::vector<QInterfaceEngine> eng, bitLenIn
 #if ENABLE_OPENCL
     if ((engineTypes.size() == 1U) && (engineTypes[0U] == QINTERFACE_OPTIMAL_BASE)) {
         isDefaultPaging = true;
+        isPagingVsBdt = devList.size() || getenv("QRACK_QPAGER_DEVICES");
 
         DeviceContextPtr devContext = OCLEngine::Instance().GetDeviceContextPtr(devID);
         maxPageQubits = log2(devContext->GetMaxAlloc() / sizeof(complex));
         maxQubitPlusAncillaCount = maxPageQubits + 2U;
         if (qubitCount > maxPageQubits) {
-            if (devList.size() || getenv("QRACK_QPAGER_DEVICES")) {
+            if (isPagingVsBdt) {
                 engineTypes.push_back(QINTERFACE_QPAGER);
             } else {
                 engineTypes.push_back(QINTERFACE_BDT);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -3567,8 +3567,6 @@ QInterfacePtr QUnit::Clone()
         randGlobalPhase, useHostRam, devID, useRDRAND, isSparse, (real1_f)amplitudeFloor, deviceIDs, thresholdQubits,
         separabilityThreshold);
 
-    Finish();
-    copyPtr->Finish();
     copyPtr->SetReactiveSeparate(isReactiveSeparate);
 
     return CloneBody(copyPtr);

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -151,7 +151,7 @@ int main(int argc, char* argv[])
         opencl = true;
         hybrid = true;
         stabilizer = true;
-        bdt = true;
+        // bdt = true;
         // stabilizer_qpager = true;
         // stabilizer_bdt = true;
     }

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -152,8 +152,8 @@ int main(int argc, char* argv[])
         hybrid = true;
         stabilizer = true;
         bdt = true;
-        stabilizer_bdt = true;
         // stabilizer_qpager = true;
+        // stabilizer_bdt = true;
     }
 
     if (devListStr.compare("") != 0) {

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -151,9 +151,9 @@ int main(int argc, char* argv[])
         opencl = true;
         hybrid = true;
         stabilizer = true;
-        // bdt = true;
+        bdt = true;
+        stabilizer_bdt = true;
         // stabilizer_qpager = true;
-        // stabilizer_bdt = true;
     }
 
     if (devListStr.compare("") != 0) {

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -2773,6 +2773,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_isfinished")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_tryseparate")
 {
+    const bool isStabilizerQBdt =
+        (testSubSubEngineType == QINTERFACE_BDT) && (testSubEngineType == QINTERFACE_STABILIZER_HYBRID);
+
     bitLenInt toSep[2];
 
     qftReg->SetPermutation(85);
@@ -2785,8 +2788,10 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_tryseparate")
 
     for (i = 0; i < 8; i++) {
         qftReg->TrySeparate(i);
-        toSep[0] = i;
-        qftReg->TrySeparate(toSep, 1, FP_NORM_EPSILON_F);
+        if (!isStabilizerQBdt) {
+            toSep[0] = i;
+            qftReg->TrySeparate(toSep, 1, FP_NORM_EPSILON_F);
+        }
     }
 
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 85));
@@ -2797,9 +2802,11 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_tryseparate")
     qftReg->CNOT(0, 2);
     qftReg->CNOT(0, 2);
     qftReg->TrySeparate(0, 1);
-    toSep[0] = 0;
-    toSep[1] = 1;
-    qftReg->TrySeparate(toSep, 2, FP_NORM_EPSILON_F);
+    if (!isStabilizerQBdt) {
+        toSep[0] = 0;
+        toSep[1] = 1;
+        qftReg->TrySeparate(toSep, 2, FP_NORM_EPSILON_F);
+    }
     qftReg->CNOT(0, 1);
     qftReg->Z(0);
     qftReg->H(0);


### PR DESCRIPTION
This branch debugs and optimizes `QBdt` layer generally, making it appropriate as an alternative to `QPager` for OpenCL single-device environments. By default, `--optimal` settings will use `QBdt` as an analogue to replace `QPager`. If multiple OpenCL devices are specified for utilization, via environment variables or statically linked constructors, then `QPager` will still be used as the default option instead of `QBdt`.