### PR TITLE
Qrack v8 API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.9)
-project (Qrack VERSION 7.1.1 DESCRIPTION "High Performance Quantum Bit Simulation")
+project (Qrack VERSION 8.0.0 DESCRIPTION "High Performance Quantum Bit Simulation")
 
 # Installation commands
 include (GNUInstallDirs)

--- a/doxygen.config
+++ b/doxygen.config
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Qrack"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 7.1
+PROJECT_NUMBER         = 8.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/examples/cosmology.cpp
+++ b/examples/cosmology.cpp
@@ -53,8 +53,8 @@ int main()
         // QFT already reverses order:
         // std::reverse(expBits.begin(), expBits.end());
 
-        std::cout << "Folds=" << (real1)(i + 1U)
-                  << ", Manifold size=" << qReg->ExpectationBitsAll(&(expBits[0]), expBits.size()) << std::endl;
+        std::cout << "Folds=" << (real1)(i + 1U) << ", Manifold size=" << qReg->ExpectationBitsAll(expBits)
+                  << std::endl;
 
         if (i < (maxLength - 1U)) {
             AddBit(qReg);

--- a/examples/qneuron_classification.cpp
+++ b/examples/qneuron_classification.cpp
@@ -94,7 +94,7 @@ void makeGeoPowerSetQnn(
 {
     bitCapIntOcl neuronCount = pow2Ocl(predictorCount);
 
-    bitCapIntOcl i, x, y, z;
+    bitCapIntOcl i, x, y;
 
     std::vector<bitLenInt> allInputIndices(predictorCount);
     for (bitLenInt i = 0; i < predictorCount; i++) {
@@ -107,18 +107,16 @@ void makeGeoPowerSetQnn(
 
         x = 0;
         y = i;
-        z = 0;
 
         while (y > 0) {
             if ((y & 1U) == 1U) {
                 inputIndices.push_back(allInputIndices[x]);
-                z++;
             }
             x++;
             y = y >> 1U;
         }
 
-        outputLayer.push_back(std::make_shared<QNeuron>(qReg, &(inputIndices[0]), z, 0));
+        outputLayer.push_back(std::make_shared<QNeuron>(qReg, inputIndices, 0));
         etas.push_back((ONE_R1 / (real1)nCr(predictorCount, x)) / (real1)pow2Ocl(x));
     }
 }

--- a/examples/quantum_associative_memory.cpp
+++ b/examples/quantum_associative_memory.cpp
@@ -31,14 +31,14 @@ int main()
     // QEngineCPU.
     QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_OPTIMAL, InputCount + OutputCount, 0);
 
-    bitLenInt inputIndices[InputCount];
+    std::vector<bitLenInt> inputIndices(InputCount);
     for (bitLenInt i = 0; i < InputCount; i++) {
         inputIndices[i] = i;
     }
 
     std::vector<QNeuronPtr> outputLayer;
     for (bitLenInt i = 0; i < OutputCount; i++) {
-        outputLayer.push_back(std::make_shared<QNeuron>(qReg, inputIndices, InputCount, InputCount + i));
+        outputLayer.push_back(std::make_shared<QNeuron>(qReg, inputIndices, InputCount + i));
     }
 
     // Train the network to associate powers of 2 with their log2()

--- a/examples/quantum_perceptron.cpp
+++ b/examples/quantum_perceptron.cpp
@@ -29,12 +29,12 @@ int main()
     // QEngineCPU.
     QInterfacePtr qReg = CreateQuantumInterface(QINTERFACE_OPTIMAL, ControlCount + 1, 0);
 
-    bitLenInt inputIndices[ControlCount];
+    std::vector<bitLenInt> inputIndices(ControlCount);
     for (bitLenInt i = 0; i < ControlCount; i++) {
         inputIndices[i] = i;
     }
 
-    QNeuronPtr qPerceptron = std::make_shared<QNeuron>(qReg, inputIndices, ControlCount, ControlCount);
+    QNeuronPtr qPerceptron = std::make_shared<QNeuron>(qReg, inputIndices, ControlCount);
 
     // Train the network to recognize powers of 2
     bool isPowerOf2;

--- a/include/common/parallel_for.hpp
+++ b/include/common/parallel_for.hpp
@@ -58,8 +58,8 @@ public:
         const bitLenInt skipBitCount, ParallelFunc fn);
 
     /** Skip over the bits listed in maskArray in the same fashion as par_for_skip. */
-    void par_for_mask(const bitCapIntOcl, const bitCapIntOcl, const bitCapIntOcl* maskArray, const bitLenInt maskLen,
-        ParallelFunc fn);
+    void par_for_mask(
+        const bitCapIntOcl, const bitCapIntOcl, const std::vector<bitCapIntOcl>& maskArray, ParallelFunc fn);
 
     /** Iterate over a sparse state vector. */
     void par_for_set(const std::set<bitCapIntOcl>& sparseSet, ParallelFunc fn);

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -276,7 +276,7 @@ void log2x2(const complex* matrix2x2, complex* outMatrix2x2);
 void inv2x2(const complex* matrix2x2, complex* outMatrix2x2);
 bool isOverflowAdd(bitCapInt inOutInt, bitCapInt inInt, const bitCapInt& signMask, const bitCapInt& lengthPower);
 bool isOverflowSub(bitCapInt inOutInt, bitCapInt inInt, const bitCapInt& signMask, const bitCapInt& lengthPower);
-bitCapInt pushApartBits(const bitCapInt& perm, const bitCapInt* skipPowers, const bitLenInt skipPowersCount);
+bitCapInt pushApartBits(const bitCapInt& perm, const std::cout<bitCapInt>& skipPowers);
 bitCapInt intPow(bitCapInt base, bitCapInt power);
 bitCapIntOcl intPowOcl(bitCapIntOcl base, bitCapIntOcl power);
 #if QBCAPPOW == 7U

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -275,9 +275,9 @@ inline bool isBadPermRange(const bitCapIntOcl& start, const bitCapIntOcl& length
     return ((start + length) > maxQPowerOcl) || ((bitCapIntOcl)(start + length) < start);
 }
 inline void ThrowIfQbIdArrayIsBad(
-    bitLenInt const* controls, const bitLenInt controlLen, const bitLenInt& qubitCount, std::string message)
+    const std::vector<bitLenInt>& controls, const bitLenInt& qubitCount, std::string message)
 {
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         if (controls[i] >= qubitCount) {
             throw std::invalid_argument(message);
         }

--- a/include/mpsshard.hpp
+++ b/include/mpsshard.hpp
@@ -15,11 +15,11 @@ struct MpsShard {
         // Intentionally left blank
     }
 
-    MpsShard(const complex* g) { std::copy(g, g + 4, gate); }
+    MpsShard(complex const* g) { std::copy(g, g + 4, gate); }
 
     MpsShardPtr Clone() { return std::make_shared<MpsShard>(gate); }
 
-    void Compose(const complex* g)
+    void Compose(complex const* g)
     {
         complex o[4U];
         std::copy(gate, gate + 4U, o);

--- a/include/qalu.hpp
+++ b/include/qalu.hpp
@@ -40,11 +40,9 @@ public:
     /** Add integer (without sign) */
     virtual void DEC(bitCapInt toSub, bitLenInt start, bitLenInt length) = 0;
     /** Add integer (without sign, with controls) */
-    virtual void CINC(
-        bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt const* controls, bitLenInt controlLen) = 0;
+    virtual void CINC(bitCapInt toAdd, bitLenInt start, bitLenInt length, const std::vector<bitLenInt>& controls) = 0;
     /** Subtract integer (without sign, with controls) */
-    virtual void CDEC(
-        bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt const* controls, bitLenInt controlLen);
+    virtual void CDEC(bitCapInt toSub, bitLenInt start, bitLenInt length, const std::vector<bitLenInt>& controls);
     /** Add integer (without sign, with carry) */
     virtual void INCC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
     /** Subtract classical integer (without sign, with carry) */
@@ -85,19 +83,19 @@ public:
         bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length) = 0;
     /** Controlled multiplication by integer */
     virtual void CMUL(bitCapInt toMul, bitLenInt start, bitLenInt carryStart, bitLenInt length,
-        bitLenInt const* controls, bitLenInt controlLen) = 0;
+        const std::vector<bitLenInt>& controls) = 0;
     /** Controlled division by power of integer */
     virtual void CDIV(bitCapInt toDiv, bitLenInt start, bitLenInt carryStart, bitLenInt length,
-        bitLenInt const* controls, bitLenInt controlLen) = 0;
+        const std::vector<bitLenInt>& controls) = 0;
     /** Controlled multiplication modulo N by integer, (out of place) */
     virtual void CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        bitLenInt const* controls, bitLenInt controlLen) = 0;
+        const std::vector<bitLenInt>& controls) = 0;
     /** Inverse of controlled multiplication modulo N by integer, (out of place) */
     virtual void CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        bitLenInt const* controls, bitLenInt controlLen) = 0;
+        const std::vector<bitLenInt>& controls) = 0;
     /** Controlled, raise a classical base to a quantum power, modulo N, (out of place) */
     virtual void CPOWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        bitLenInt const* controls, bitLenInt controlLen) = 0;
+        const std::vector<bitLenInt>& controls) = 0;
 
 #if ENABLE_BCD
     /** Add classical BCD integer (without sign) */

--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -100,7 +100,7 @@ protected:
     void DecomposeDispose(bitLenInt start, bitLenInt length, QBdtPtr dest);
 
     void ApplyControlledSingle(
-        const complex* mtrx, const std::vector<bitLenInt>& controls, bitLenInt target, bool isAnti);
+        complex const* mtrx, const std::vector<bitLenInt>& controls, bitLenInt target, bool isAnti);
 
     static size_t SelectBit(bitCapInt perm, bitLenInt bit) { return (size_t)((perm >> bit) & 1U); }
 
@@ -110,7 +110,7 @@ protected:
         return (perm & mask) | ((perm >> ONE_BCI) & ~mask);
     }
 
-    void ApplySingle(const complex* mtrx, bitLenInt target);
+    void ApplySingle(complex const* mtrx, bitLenInt target);
 
     void Init();
 
@@ -197,7 +197,7 @@ public:
 
     void GetQuantumState(complex* state);
     void GetQuantumState(QInterfacePtr eng);
-    void SetQuantumState(const complex* state);
+    void SetQuantumState(complex const* state);
     void SetQuantumState(QInterfacePtr eng);
     void GetProbs(real1* outputProbs);
 
@@ -264,9 +264,9 @@ public:
     bool ForceM(bitLenInt qubit, bool result, bool doForce = true, bool doApply = true);
     bitCapInt MAll();
 
-    void Mtrx(const complex* mtrx, bitLenInt target);
-    void MCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target);
-    void MACMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target);
+    void Mtrx(complex const* mtrx, bitLenInt target);
+    void MCMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target);
+    void MACMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target);
     void MCPhase(const std::vector<bitLenInt>& controls, complex topLeft, complex bottomRight, bitLenInt target);
     void MACPhase(const std::vector<bitLenInt>& controls, complex topLeft, complex bottomRight, bitLenInt target);
     void MCInvert(const std::vector<bitLenInt>& controls, complex topRight, complex bottomLeft, bitLenInt target);

--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -100,7 +100,7 @@ protected:
     void DecomposeDispose(bitLenInt start, bitLenInt length, QBdtPtr dest);
 
     void ApplyControlledSingle(
-        const complex* mtrx, const bitLenInt* controls, bitLenInt controlLen, bitLenInt target, bool isAnti);
+        const complex* mtrx, const std::vector<bitLenInt>& controls, bitLenInt target, bool isAnti);
 
     static size_t SelectBit(bitCapInt perm, bitLenInt bit) { return (size_t)((perm >> bit) & 1U); }
 
@@ -265,16 +265,12 @@ public:
     bitCapInt MAll();
 
     void Mtrx(const complex* mtrx, bitLenInt target);
-    void MCMtrx(const bitLenInt* controls, bitLenInt controlLen, const complex* mtrx, bitLenInt target);
-    void MACMtrx(const bitLenInt* controls, bitLenInt controlLen, const complex* mtrx, bitLenInt target);
-    void MCPhase(
-        const bitLenInt* controls, bitLenInt controlLen, complex topLeft, complex bottomRight, bitLenInt target);
-    void MACPhase(
-        const bitLenInt* controls, bitLenInt controlLen, complex topLeft, complex bottomRight, bitLenInt target);
-    void MCInvert(
-        const bitLenInt* controls, bitLenInt controlLen, complex topRight, complex bottomLeft, bitLenInt target);
-    void MACInvert(
-        const bitLenInt* controls, bitLenInt controlLen, complex topRight, complex bottomLeft, bitLenInt target);
+    void MCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target);
+    void MACMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target);
+    void MCPhase(const std::vector<bitLenInt>& controls, complex topLeft, complex bottomRight, bitLenInt target);
+    void MACPhase(const std::vector<bitLenInt>& controls, complex topLeft, complex bottomRight, bitLenInt target);
+    void MCInvert(const std::vector<bitLenInt>& controls, complex topRight, complex bottomLeft, bitLenInt target);
+    void MACInvert(const std::vector<bitLenInt>& controls, complex topRight, complex bottomLeft, bitLenInt target);
 
     void FSim(real1_f theta, real1_f phi, bitLenInt qubitIndex1, bitLenInt qubitIndex2)
     {
@@ -296,11 +292,10 @@ public:
             [&](QInterfacePtr eng) { toRet = QINTERFACE_TO_QPARITY(NODE_TO_QENGINE(root))->ProbParity(mask); });
         return toRet;
     }
-    void CUniformParityRZ(const bitLenInt* controls, bitLenInt controlLen, bitCapInt mask, real1_f angle)
+    void CUniformParityRZ(const std::vector<bitLenInt>& controls, bitCapInt mask, real1_f angle)
     {
-        ExecuteAsStateVector([&](QInterfacePtr eng) {
-            QINTERFACE_TO_QPARITY(eng)->CUniformParityRZ(controls, controlLen, mask, angle);
-        });
+        ExecuteAsStateVector(
+            [&](QInterfacePtr eng) { QINTERFACE_TO_QPARITY(eng)->CUniformParityRZ(controls, mask, angle); });
     }
     bool ForceMParity(bitCapInt mask, bool result, bool doForce = true)
     {
@@ -341,13 +336,13 @@ public:
     {
         QInterface::DECS(toSub, start, length, overflowIndex);
     }
-    void CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const bitLenInt* controls, bitLenInt controlLen)
+    void CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const std::vector<bitLenInt>& controls)
     {
-        QInterface::CINC(toAdd, inOutStart, length, controls, controlLen);
+        QInterface::CINC(toAdd, inOutStart, length, controls);
     }
-    void CDEC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, const bitLenInt* controls, bitLenInt controlLen)
+    void CDEC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, const std::vector<bitLenInt>& controls)
     {
-        QInterface::CDEC(toSub, inOutStart, length, controls, controlLen);
+        QInterface::CDEC(toSub, inOutStart, length, controls);
     }
     void INCDECC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
     {
@@ -362,17 +357,17 @@ public:
         QInterface::IMULModNOut(toMul, modN, inStart, outStart, length);
     }
     void CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        const bitLenInt* controls, bitLenInt controlLen)
+        const std::vector<bitLenInt>& controls)
     {
         ExecuteAsStateVector([&](QInterfacePtr eng) {
-            QINTERFACE_TO_QALU(eng)->CMULModNOut(toMul, modN, inStart, outStart, length, controls, controlLen);
+            QINTERFACE_TO_QALU(eng)->CMULModNOut(toMul, modN, inStart, outStart, length, controls);
         });
     }
     void CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        const bitLenInt* controls, bitLenInt controlLen)
+        const std::vector<bitLenInt>& controls)
     {
         ExecuteAsStateVector([&](QInterfacePtr eng) {
-            QINTERFACE_TO_QALU(eng)->CIMULModNOut(toMul, modN, inStart, outStart, length, controls, controlLen);
+            QINTERFACE_TO_QALU(eng)->CIMULModNOut(toMul, modN, inStart, outStart, length, controls);
         });
     }
     void PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length)
@@ -423,25 +418,23 @@ public:
         ExecuteAsStateVector(
             [&](QInterfacePtr eng) { QINTERFACE_TO_QALU(eng)->POWModNOut(base, modN, inStart, outStart, length); });
     }
-    void CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length, const bitLenInt* controls,
-        bitLenInt controlLen)
+    void CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
+        const std::vector<bitLenInt>& controls)
     {
-        ExecuteAsStateVector([&](QInterfacePtr eng) {
-            QINTERFACE_TO_QALU(eng)->CMUL(toMul, inOutStart, carryStart, length, controls, controlLen);
-        });
+        ExecuteAsStateVector(
+            [&](QInterfacePtr eng) { QINTERFACE_TO_QALU(eng)->CMUL(toMul, inOutStart, carryStart, length, controls); });
     }
-    void CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length, const bitLenInt* controls,
-        bitLenInt controlLen)
+    void CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
+        const std::vector<bitLenInt>& controls)
     {
-        ExecuteAsStateVector([&](QInterfacePtr eng) {
-            QINTERFACE_TO_QALU(eng)->CDIV(toDiv, inOutStart, carryStart, length, controls, controlLen);
-        });
+        ExecuteAsStateVector(
+            [&](QInterfacePtr eng) { QINTERFACE_TO_QALU(eng)->CDIV(toDiv, inOutStart, carryStart, length, controls); });
     }
     void CPOWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        const bitLenInt* controls, bitLenInt controlLen)
+        const std::vector<bitLenInt>& controls)
     {
         ExecuteAsStateVector([&](QInterfacePtr eng) {
-            QINTERFACE_TO_QALU(eng)->CPOWModNOut(base, modN, inStart, outStart, length, controls, controlLen);
+            QINTERFACE_TO_QALU(eng)->CPOWModNOut(base, modN, inStart, outStart, length, controls);
         });
     }
     bitCapInt IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,

--- a/include/qbdt_node.hpp
+++ b/include/qbdt_node.hpp
@@ -30,7 +30,7 @@ protected:
         QBdtNodeInterfacePtr& b1, bitLenInt depth);
 #else
     virtual void PushStateVector(
-        const complex* mtrx, QBdtNodeInterfacePtr& b0, QBdtNodeInterfacePtr& b1, bitLenInt depth);
+        complex const* mtrx, QBdtNodeInterfacePtr& b0, QBdtNodeInterfacePtr& b1, bitLenInt depth);
 #endif
 
 public:
@@ -72,7 +72,7 @@ public:
 #if ENABLE_COMPLEX_X2
     virtual void Apply2x2(const complex2& mtrxCol1, const complex2& mtrxCol2, bitLenInt depth);
 #else
-    virtual void Apply2x2(const complex* mtrx, bitLenInt depth);
+    virtual void Apply2x2(complex const* mtrx, bitLenInt depth);
 #endif
 };
 

--- a/include/qbdt_node_interface.hpp
+++ b/include/qbdt_node_interface.hpp
@@ -40,7 +40,7 @@ protected:
         QBdtNodeInterfacePtr& b1, bitLenInt depth) = 0;
 #else
     virtual void PushStateVector(
-        const complex* mtrx, QBdtNodeInterfacePtr& b0, QBdtNodeInterfacePtr& b1, bitLenInt depth) = 0;
+        complex const* mtrx, QBdtNodeInterfacePtr& b0, QBdtNodeInterfacePtr& b1, bitLenInt depth) = 0;
 #endif
 
 public:
@@ -101,13 +101,13 @@ public:
 #if ENABLE_COMPLEX_X2
     virtual void Apply2x2(const complex2& mtrxCol1, const complex2& mtrxCol2, bitLenInt depth) = 0;
 #else
-    virtual void Apply2x2(const complex* mtrx, bitLenInt depth) = 0;
+    virtual void Apply2x2(complex const* mtrx, bitLenInt depth) = 0;
 #endif
 
 #if ENABLE_COMPLEX_X2
     virtual void PushSpecial(const complex2& mtrxCol1, const complex2& mtrxCol2, QBdtNodeInterfacePtr& b1)
 #else
-    virtual void PushSpecial(const complex* mtrx, QBdtNodeInterfacePtr& b1)
+    virtual void PushSpecial(complex const* mtrx, QBdtNodeInterfacePtr& b1)
 #endif
     {
         throw std::out_of_range("QBdtNodeInterface::PushSpecial() not implemented! (You probably called "

--- a/include/qbdt_qengine_node.hpp
+++ b/include/qbdt_qengine_node.hpp
@@ -31,7 +31,7 @@ protected:
         QBdtNodeInterfacePtr& b1, bitLenInt depth)
 #else
     virtual void PushStateVector(
-        const complex* mtrx, QBdtNodeInterfacePtr& b0, QBdtNodeInterfacePtr& b1, bitLenInt depth)
+        complex const* mtrx, QBdtNodeInterfacePtr& b0, QBdtNodeInterfacePtr& b1, bitLenInt depth)
 #endif
     {
         throw std::out_of_range("QBdtQEngineNode::PushStateVector() not implemented!");
@@ -81,7 +81,7 @@ public:
 #if ENABLE_COMPLEX_X2
     virtual void Apply2x2(const complex2& mtrxCol1, const complex2& mtrxCol2, bitLenInt depth)
 #else
-    virtual void Apply2x2(const complex* mtrx, bitLenInt depth)
+    virtual void Apply2x2(complex const* mtrx, bitLenInt depth)
 #endif
     {
         throw std::out_of_range("QBdtQEngineNode::Apply2x2() not implemented!");
@@ -89,7 +89,7 @@ public:
 #if ENABLE_COMPLEX_X2
     virtual void PushSpecial(const complex2& mtrxCol1, const complex2& mtrxCol2, QBdtNodeInterfacePtr& b1);
 #else
-    virtual void PushSpecial(const complex* mtrx, QBdtNodeInterfacePtr& b1);
+    virtual void PushSpecial(complex const* mtrx, QBdtNodeInterfacePtr& b1);
 #endif
 };
 

--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -107,7 +107,7 @@ public:
     virtual void ZMask(bitCapInt mask) { PhaseParity((real1_f)PI_R1, mask); }
 
     virtual bool ForceM(bitLenInt qubitIndex, bool result, bool doForce = true, bool doApply = true);
-    virtual bitCapInt ForceM(const std::vector<bitLenInt>& bits, bool const* values, bool doApply = true);
+    virtual bitCapInt ForceM(const std::vector<bitLenInt>& bits, const std::vector<bool>& values, bool doApply = true);
     virtual bitCapInt ForceMReg(
         bitLenInt start, bitLenInt length, bitCapInt result, bool doForce = true, bool doApply = true);
 

--- a/include/qengine.hpp
+++ b/include/qengine.hpp
@@ -107,7 +107,7 @@ public:
     virtual void ZMask(bitCapInt mask) { PhaseParity((real1_f)PI_R1, mask); }
 
     virtual bool ForceM(bitLenInt qubitIndex, bool result, bool doForce = true, bool doApply = true);
-    virtual bitCapInt ForceM(bitLenInt const* bits, bitLenInt length, bool const* values, bool doApply = true);
+    virtual bitCapInt ForceM(const std::vector<bitLenInt>& bits, bool const* values, bool doApply = true);
     virtual bitCapInt ForceMReg(
         bitLenInt start, bitLenInt length, bitCapInt result, bool doForce = true, bool doApply = true);
 
@@ -119,14 +119,14 @@ public:
     virtual void ApplyM(bitCapInt regMask, bitCapInt result, complex nrm) = 0;
 
     virtual void Mtrx(complex const* mtrx, bitLenInt qubit);
-    virtual void MCMtrx(bitLenInt const* controls, bitLenInt controlLen, complex const* mtrx, bitLenInt target);
-    virtual void MACMtrx(bitLenInt const* controls, bitLenInt controlLen, complex const* mtrx, bitLenInt target);
-    virtual void CSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2);
-    virtual void AntiCSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2);
-    virtual void CSqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2);
-    virtual void AntiCSqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2);
-    virtual void CISqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2);
-    virtual void AntiCISqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2);
+    virtual void MCMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target);
+    virtual void MACMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target);
+    virtual void CSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2);
+    virtual void AntiCSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2);
+    virtual void CSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2);
+    virtual void AntiCSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2);
+    virtual void CISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2);
+    virtual void AntiCISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2);
 
 #if ENABLE_ALU
     using QInterface::M;
@@ -151,15 +151,13 @@ public:
     {
         QInterface::DECS(toSub, start, length, overflowIndex);
     }
-    virtual void CINC(
-        bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, bitLenInt const* controls, bitLenInt controlLen)
+    virtual void CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const std::vector<bitLenInt>& controls)
     {
-        QInterface::CINC(toAdd, inOutStart, length, controls, controlLen);
+        QInterface::CINC(toAdd, inOutStart, length, controls);
     }
-    virtual void CDEC(
-        bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, bitLenInt const* controls, bitLenInt controlLen)
+    virtual void CDEC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, const std::vector<bitLenInt>& controls)
     {
-        QInterface::CDEC(toSub, inOutStart, length, controls, controlLen);
+        QInterface::CDEC(toSub, inOutStart, length, controls);
     }
     virtual void INCDECC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
     {
@@ -174,14 +172,14 @@ public:
         QInterface::IMULModNOut(toMul, modN, inStart, outStart, length);
     }
     virtual void CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        bitLenInt const* controls, bitLenInt controlLen)
+        const std::vector<bitLenInt>& controls)
     {
-        QInterface::CMULModNOut(toMul, modN, inStart, outStart, length, controls, controlLen);
+        QInterface::CMULModNOut(toMul, modN, inStart, outStart, length, controls);
     }
     virtual void CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        bitLenInt const* controls, bitLenInt controlLen)
+        const std::vector<bitLenInt>& controls)
     {
-        QInterface::CIMULModNOut(toMul, modN, inStart, outStart, length, controls, controlLen);
+        QInterface::CIMULModNOut(toMul, modN, inStart, outStart, length, controls);
     }
 #endif
 
@@ -210,10 +208,8 @@ public:
 
     virtual void Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, complex const* mtrx, bitLenInt bitCount,
         bitCapIntOcl const* qPowersSorted, bool doCalcNorm, real1_f norm_thresh = REAL1_DEFAULT_ARG) = 0;
-    virtual void ApplyControlled2x2(
-        bitLenInt const* controls, bitLenInt controlLen, bitLenInt target, complex const* mtrx);
-    virtual void ApplyAntiControlled2x2(
-        bitLenInt const* controls, bitLenInt controlLen, bitLenInt target, complex const* mtrx);
+    virtual void ApplyControlled2x2(const std::vector<bitLenInt>& controls, bitLenInt target, complex const* mtrx);
+    virtual void ApplyAntiControlled2x2(const std::vector<bitLenInt>& controls, bitLenInt target, complex const* mtrx);
 
     using QInterface::Decompose;
     virtual QInterfacePtr Decompose(bitLenInt start, bitLenInt length);

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -98,7 +98,7 @@ public:
 
     bool IsZeroAmplitude() { return !stateVec; }
     void GetAmplitudePage(complex* pagePtr, bitCapIntOcl offset, bitCapIntOcl length);
-    void SetAmplitudePage(const complex* pagePtr, bitCapIntOcl offset, bitCapIntOcl length);
+    void SetAmplitudePage(complex const* pagePtr, bitCapIntOcl offset, bitCapIntOcl length);
     void SetAmplitudePage(
         QEnginePtr pageEnginePtr, bitCapIntOcl srcOffset, bitCapIntOcl dstOffset, bitCapIntOcl length);
     void ShuffleBuffers(QEnginePtr engine);
@@ -115,7 +115,7 @@ public:
         Dispatch(1U, [this, runningNrm] { runningNorm = runningNrm; });
     }
 
-    void SetQuantumState(const complex* inputState);
+    void SetQuantumState(complex const* inputState);
     void GetQuantumState(complex* outputState);
     void GetProbs(real1* outputProbs);
     complex GetAmplitude(bitCapInt perm);
@@ -245,7 +245,7 @@ protected:
     }
 
     void DecomposeDispose(bitLenInt start, bitLenInt length, QEngineCPUPtr dest);
-    void Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const complex* mtrx, bitLenInt bitCount,
+    void Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, complex const* mtrx, bitLenInt bitCount,
         const bitCapIntOcl* qPowersSorted, bool doCalcNorm, real1_f norm_thresh = REAL1_DEFAULT_ARG);
     void UpdateRunningNorm(real1_f norm_thresh = REAL1_DEFAULT_ARG);
     using QEngine::ApplyM;

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -154,7 +154,7 @@ public:
     void ROL(bitLenInt shift, bitLenInt start, bitLenInt length);
 #if ENABLE_ALU
     void INC(bitCapInt toAdd, bitLenInt start, bitLenInt length);
-    void CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const bitLenInt* controls, bitLenInt controlLen);
+    void CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const std::vector<bitLenInt>& controls);
     void INCS(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex);
 #if ENABLE_BCD
     void INCBCD(bitCapInt toAdd, bitLenInt start, bitLenInt length);
@@ -164,16 +164,16 @@ public:
     void MULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length);
     void IMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length);
     void POWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length);
-    void CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length, const bitLenInt* controls,
-        bitLenInt controlLen);
-    void CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length, const bitLenInt* controls,
-        bitLenInt controlLen);
+    void CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
+        const std::vector<bitLenInt>& controls);
+    void CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
+        const std::vector<bitLenInt>& controls);
     void CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        const bitLenInt* controls, bitLenInt controlLen);
+        const std::vector<bitLenInt>& controls);
     void CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        const bitLenInt* controls, bitLenInt controlLen);
+        const std::vector<bitLenInt>& controls);
     void CPOWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        const bitLenInt* controls, bitLenInt controlLen);
+        const std::vector<bitLenInt>& controls);
     void FullAdd(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt carryInSumOut, bitLenInt carryOut);
     void IFullAdd(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt carryInSumOut, bitLenInt carryOut);
     bitCapInt IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
@@ -197,10 +197,10 @@ public:
 
     void SetPermutation(bitCapInt perm, complex phaseFac = CMPLX_DEFAULT_ARG);
     using QEngine::UniformlyControlledSingleBit;
-    void UniformlyControlledSingleBit(const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubitIndex,
+    void UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls, bitLenInt qubitIndex,
         const complex* mtrxs, const bitCapInt* mtrxSkipPowers, bitLenInt mtrxSkipLen, bitCapInt mtrxSkipValueMask);
     void UniformParityRZ(bitCapInt mask, real1_f angle);
-    void CUniformParityRZ(const bitLenInt* controls, bitLenInt controlLen, bitCapInt mask, real1_f angle);
+    void CUniformParityRZ(const std::vector<bitLenInt>& controls, bitCapInt mask, real1_f angle);
 
     /** @} */
 
@@ -264,13 +264,13 @@ protected:
     void MULDIV(const IOFn& inFn, const IOFn& outFn, const bitCapInt& toMul, const bitLenInt& inOutStart,
         const bitLenInt& carryStart, const bitLenInt& length);
     void CMULDIV(const IOFn& inFn, const IOFn& outFn, const bitCapInt& toMul, const bitLenInt& inOutStart,
-        const bitLenInt& carryStart, const bitLenInt& length, const bitLenInt* controls, const bitLenInt controlLen);
+        const bitLenInt& carryStart, const bitLenInt& length, const std::vector<bitLenInt>& controls);
 
     typedef std::function<bitCapIntOcl(const bitCapIntOcl&)> MFn;
     void ModNOut(const MFn& kernelFn, const bitCapInt& modN, const bitLenInt& inStart, const bitLenInt& outStart,
         const bitLenInt& length, const bool& inverse = false);
     void CModNOut(const MFn& kernelFn, const bitCapInt& modN, const bitLenInt& inStart, const bitLenInt& outStart,
-        const bitLenInt& length, const bitLenInt* controls, const bitLenInt& controlLen, const bool& inverse = false);
+        const bitLenInt& length, const std::vector<bitLenInt>& controls, const bool& inverse = false);
 #endif
 };
 } // namespace Qrack

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -198,7 +198,7 @@ public:
     void SetPermutation(bitCapInt perm, complex phaseFac = CMPLX_DEFAULT_ARG);
     using QEngine::UniformlyControlledSingleBit;
     void UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls, bitLenInt qubitIndex,
-        const complex* mtrxs, const bitCapInt* mtrxSkipPowers, bitLenInt mtrxSkipLen, bitCapInt mtrxSkipValueMask);
+        complex const* mtrxs, bitCapInt const* mtrxSkipPowers, bitLenInt mtrxSkipLen, bitCapInt mtrxSkipValueMask);
     void UniformParityRZ(bitCapInt mask, real1_f angle);
     void CUniformParityRZ(const std::vector<bitLenInt>& controls, bitCapInt mask, real1_f angle);
 

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -360,10 +360,10 @@ public:
     void SetPermutation(bitCapInt perm, complex phaseFac = CMPLX_DEFAULT_ARG);
 
     using QEngine::UniformlyControlledSingleBit;
-    void UniformlyControlledSingleBit(const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubitIndex,
-        const complex* mtrxs, const bitCapInt* mtrxSkipPowers, bitLenInt mtrxSkipLen, bitCapInt mtrxSkipValueMask);
+    void UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls, bitLenInt qubitIndex,
+        const complex* mtrxs, const std::vector<bitCapInt>& mtrxSkipPowers, bitCapInt mtrxSkipValueMask);
     void UniformParityRZ(bitCapInt mask, real1_f angle);
-    void CUniformParityRZ(const bitLenInt* controls, bitLenInt controlLen, bitCapInt mask, real1_f angle);
+    void CUniformParityRZ(const std::vector<bitLenInt>& controls, bitCapInt mask, real1_f angle);
 
     /* Operations that have an improved implementation. */
     using QEngine::X;
@@ -422,7 +422,7 @@ public:
 
 #if ENABLE_ALU
     void INC(bitCapInt toAdd, bitLenInt start, bitLenInt length);
-    void CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const bitLenInt* controls, bitLenInt controlLen);
+    void CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const std::vector<bitLenInt>& controls);
     void INCS(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
 #if ENABLE_BCD
     void INCBCD(bitCapInt toAdd, bitLenInt start, bitLenInt length);
@@ -432,16 +432,16 @@ public:
     void MULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length);
     void IMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length);
     void POWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length);
-    void CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length, const bitLenInt* controls,
-        bitLenInt controlLen);
-    void CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length, const bitLenInt* controls,
-        bitLenInt controlLen);
+    void CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
+        const std::vector<bitLenInt>& controls);
+    void CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
+        const std::vector<bitLenInt>& controls);
     void CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        const bitLenInt* controls, bitLenInt controlLen);
+        const std::vector<bitLenInt>& controls);
     void CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        const bitLenInt* controls, bitLenInt controlLen);
+        const std::vector<bitLenInt>& controls);
     void CPOWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        const bitLenInt* controls, bitLenInt controlLen);
+        const std::vector<bitLenInt>& controls);
     void FullAdd(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt carryInSumOut, bitLenInt carryOut);
     void IFullAdd(bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt carryInSumOut, bitLenInt carryOut);
 
@@ -465,7 +465,7 @@ public:
     void ProbMaskAll(bitCapInt mask, real1* probsArray);
     real1_f ProbParity(bitCapInt mask);
     bool ForceMParity(bitCapInt mask, bool result, bool doForce = true);
-    real1_f ExpectationBitsAll(const bitLenInt* bits, bitLenInt length, bitCapInt offset = 0);
+    real1_f ExpectationBitsAll(const std::vector<bitLenInt>& bits, bitCapInt offset = 0);
 
     void SetDevice(int64_t dID);
     int64_t GetDevice() { return deviceID; }
@@ -644,8 +644,9 @@ protected:
 
     void ArithmeticCall(OCLAPI api_call, const bitCapIntOcl (&bciArgs)[BCI_ARG_LEN], const unsigned char* values = NULL,
         bitCapIntOcl valuesLength = 0U);
-    void CArithmeticCall(OCLAPI api_call, const bitCapIntOcl (&bciArgs)[BCI_ARG_LEN], bitCapIntOcl* controlPowers,
-        bitLenInt controlLen, const unsigned char* values = NULL, bitCapIntOcl valuesLength = 0U);
+    void CArithmeticCall(OCLAPI api_call, const bitCapIntOcl (&bciArgs)[BCI_ARG_LEN],
+        const std::vector<bitCapIntOcl>& controlPowers, const unsigned char* values = NULL,
+        bitCapIntOcl valuesLength = 0U);
     void ROx(OCLAPI api_call, bitLenInt shift, bitLenInt start, bitLenInt length);
 
 #if ENABLE_ALU
@@ -658,8 +659,8 @@ protected:
 #endif
 
     void INT(OCLAPI api_call, bitCapIntOcl toMod, bitLenInt inOutStart, bitLenInt length);
-    void CINT(OCLAPI api_call, bitCapIntOcl toMod, bitLenInt start, bitLenInt length, const bitLenInt* controls,
-        bitLenInt controlLen);
+    void CINT(
+        OCLAPI api_call, bitCapIntOcl toMod, bitLenInt start, bitLenInt length, const std::vector<bitLenInt>& controls);
     void INTC(OCLAPI api_call, bitCapIntOcl toMod, bitLenInt inOutStart, bitLenInt length, bitLenInt carryIndex);
     void INTS(OCLAPI api_call, bitCapIntOcl toMod, bitLenInt inOutStart, bitLenInt length, bitLenInt overflowIndex);
     void INTSC(OCLAPI api_call, bitCapIntOcl toMod, bitLenInt inOutStart, bitLenInt length, bitLenInt carryIndex);
@@ -674,9 +675,9 @@ protected:
     void MULModx(OCLAPI api_call, bitCapIntOcl toMod, bitCapIntOcl modN, bitLenInt inOutStart, bitLenInt carryStart,
         bitLenInt length);
     void CMULx(OCLAPI api_call, bitCapIntOcl toMod, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
-        const bitLenInt* controls, bitLenInt controlLen);
+        const std::vector<bitLenInt>& controls);
     void CMULModx(OCLAPI api_call, bitCapIntOcl toMod, bitCapIntOcl modN, bitLenInt inOutStart, bitLenInt carryStart,
-        bitLenInt length, const bitLenInt* controls, bitLenInt controlLen);
+        bitLenInt length, const std::vector<bitLenInt>& controls);
     void FullAdx(
         bitLenInt inputBit1, bitLenInt inputBit2, bitLenInt carryInSumOut, bitLenInt carryOut, OCLAPI api_call);
     void PhaseFlipX(OCLAPI api_call, const bitCapIntOcl* bciArgs);

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -644,9 +644,8 @@ protected:
 
     void ArithmeticCall(OCLAPI api_call, const bitCapIntOcl (&bciArgs)[BCI_ARG_LEN], const unsigned char* values = NULL,
         bitCapIntOcl valuesLength = 0U);
-    void CArithmeticCall(OCLAPI api_call, const bitCapIntOcl (&bciArgs)[BCI_ARG_LEN],
-        const std::vector<bitCapIntOcl>& controlPowers, const unsigned char* values = NULL,
-        bitCapIntOcl valuesLength = 0U);
+    void CArithmeticCall(OCLAPI api_call, const bitCapIntOcl (&bciArgs)[BCI_ARG_LEN], bitCapIntOcl* controlPowers,
+        bitLenInt controlLen, const unsigned char* values = NULL, bitCapIntOcl valuesLength = 0U);
     void ROx(OCLAPI api_call, bitLenInt shift, bitLenInt start, bitLenInt length);
 
 #if ENABLE_ALU

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -326,7 +326,7 @@ public:
     void CopyStateVec(QEnginePtr src);
 
     void GetAmplitudePage(complex* pagePtr, bitCapIntOcl offset, bitCapIntOcl length);
-    void SetAmplitudePage(const complex* pagePtr, bitCapIntOcl offset, bitCapIntOcl length);
+    void SetAmplitudePage(complex const* pagePtr, bitCapIntOcl offset, bitCapIntOcl length);
     void SetAmplitudePage(
         QEnginePtr pageEnginePtr, bitCapIntOcl srcOffset, bitCapIntOcl dstOffset, bitCapIntOcl length);
     void ShuffleBuffers(QEnginePtr engine);
@@ -361,7 +361,7 @@ public:
 
     using QEngine::UniformlyControlledSingleBit;
     void UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls, bitLenInt qubitIndex,
-        const complex* mtrxs, const std::vector<bitCapInt>& mtrxSkipPowers, bitCapInt mtrxSkipValueMask);
+        complex const* mtrxs, const std::vector<bitCapInt>& mtrxSkipPowers, bitCapInt mtrxSkipValueMask);
     void UniformParityRZ(bitCapInt mask, real1_f angle);
     void CUniformParityRZ(const std::vector<bitLenInt>& controls, bitCapInt mask, real1_f angle);
 
@@ -470,7 +470,7 @@ public:
     void SetDevice(int64_t dID);
     int64_t GetDevice() { return deviceID; }
 
-    void SetQuantumState(const complex* inputState);
+    void SetQuantumState(complex const* inputState);
     void GetQuantumState(complex* outputState);
     void GetProbs(real1* outputProbs);
     complex GetAmplitude(bitCapInt perm);
@@ -621,12 +621,12 @@ protected:
     void DecomposeDispose(bitLenInt start, bitLenInt length, QEngineOCLPtr dest);
 
     using QEngine::Apply2x2;
-    void Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const complex* mtrx, bitLenInt bitCount,
+    void Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, complex const* mtrx, bitLenInt bitCount,
         const bitCapIntOcl* qPowersSorted, bool doCalcNorm, real1_f norm_thresh = REAL1_DEFAULT_ARG)
     {
         Apply2x2(offset1, offset2, mtrx, bitCount, qPowersSorted, doCalcNorm, SPECIAL_2X2::NONE, norm_thresh);
     }
-    void Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const complex* mtrx, bitLenInt bitCount,
+    void Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, complex const* mtrx, bitLenInt bitCount,
         const bitCapIntOcl* qPowersSorted, bool doCalcNorm, SPECIAL_2X2 special,
         real1_f norm_thresh = REAL1_DEFAULT_ARG);
 

--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -395,7 +395,7 @@ public:
         engine->POWModNOut(base, modN, inStart, outStart, length);
     }
     void CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
-        const std::vector<bitLenInt>& controls, bitLenInt controlLen)
+        const std::vector<bitLenInt>& controls)
     {
         engine->CMUL(toMul, inOutStart, carryStart, length, controls);
     }

--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -299,7 +299,7 @@ public:
         engine->CUniformParityRZ(controls, mask, angle);
     }
 
-    void CSwap(const std::vector<bitLenInt>& controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2)
+    void CSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
     {
         engine->CSwap(controls, qubit1, qubit2);
     }

--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -142,7 +142,7 @@ public:
     {
         engine->GetAmplitudePage(pagePtr, offset, length);
     }
-    void SetAmplitudePage(const complex* pagePtr, bitCapIntOcl offset, bitCapIntOcl length)
+    void SetAmplitudePage(complex const* pagePtr, bitCapIntOcl offset, bitCapIntOcl length)
     {
         engine->SetAmplitudePage(pagePtr, offset, length);
     }
@@ -252,7 +252,7 @@ public:
         return result;
     }
 
-    void SetQuantumState(const complex* inputState) { engine->SetQuantumState(inputState); }
+    void SetQuantumState(complex const* inputState) { engine->SetQuantumState(inputState); }
     void GetQuantumState(complex* outputState) { engine->GetQuantumState(outputState); }
     void GetProbs(real1* outputProbs) { engine->GetProbs(outputProbs); }
     complex GetAmplitude(bitCapInt perm) { return engine->GetAmplitude(perm); }
@@ -262,7 +262,7 @@ public:
         engine->SetPermutation(perm, phaseFac);
     }
 
-    void Mtrx(const complex* mtrx, bitLenInt qubitIndex) { engine->Mtrx(mtrx, qubitIndex); }
+    void Mtrx(complex const* mtrx, bitLenInt qubitIndex) { engine->Mtrx(mtrx, qubitIndex); }
     void Phase(complex topLeft, complex bottomRight, bitLenInt qubitIndex)
     {
         engine->Phase(topLeft, bottomRight, qubitIndex);
@@ -271,18 +271,18 @@ public:
     {
         engine->Invert(topRight, bottomLeft, qubitIndex);
     }
-    void MCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
+    void MCMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target)
     {
         engine->MCMtrx(controls, mtrx, target);
     }
-    void MACMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
+    void MACMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target)
     {
         engine->MACMtrx(controls, mtrx, target);
     }
 
     using QEngine::UniformlyControlledSingleBit;
     void UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls, bitLenInt qubitIndex,
-        const complex* mtrxs, const std::vector<bitCapInt> mtrxSkipPowers, bitCapInt mtrxSkipValueMask)
+        complex const* mtrxs, const std::vector<bitCapInt> mtrxSkipPowers, bitCapInt mtrxSkipValueMask)
     {
         engine->UniformlyControlledSingleBit(controls, qubitIndex, mtrxs, mtrxSkipPowers, mtrxSkipValueMask);
     }
@@ -522,16 +522,16 @@ protected:
         return engine->GetExpectation(valueStart, valueLength);
     }
 
-    void Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const complex* mtrx, bitLenInt bitCount,
+    void Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, complex const* mtrx, bitLenInt bitCount,
         const bitCapIntOcl* qPowersSorted, bool doCalcNorm, real1_f norm_thresh = REAL1_DEFAULT_ARG)
     {
         engine->Apply2x2(offset1, offset2, mtrx, bitCount, qPowersSorted, doCalcNorm, norm_thresh);
     }
-    void ApplyControlled2x2(const std::vector<bitLenInt>& controls, bitLenInt target, const complex* mtrx)
+    void ApplyControlled2x2(const std::vector<bitLenInt>& controls, bitLenInt target, complex const* mtrx)
     {
         engine->ApplyControlled2x2(controls, target, mtrx);
     }
-    void ApplyAntiControlled2x2(const std::vector<bitLenInt>& controls, bitLenInt target, const complex* mtrx)
+    void ApplyAntiControlled2x2(const std::vector<bitLenInt>& controls, bitLenInt target, complex const* mtrx)
     {
         engine->ApplyAntiControlled2x2(controls, target, mtrx);
     }

--- a/include/qhybrid.hpp
+++ b/include/qhybrid.hpp
@@ -271,21 +271,20 @@ public:
     {
         engine->Invert(topRight, bottomLeft, qubitIndex);
     }
-    void MCMtrx(const bitLenInt* controls, bitLenInt controlLen, const complex* mtrx, bitLenInt target)
+    void MCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
     {
-        engine->MCMtrx(controls, controlLen, mtrx, target);
+        engine->MCMtrx(controls, mtrx, target);
     }
-    void MACMtrx(const bitLenInt* controls, bitLenInt controlLen, const complex* mtrx, bitLenInt target)
+    void MACMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
     {
-        engine->MACMtrx(controls, controlLen, mtrx, target);
+        engine->MACMtrx(controls, mtrx, target);
     }
 
     using QEngine::UniformlyControlledSingleBit;
-    void UniformlyControlledSingleBit(const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubitIndex,
-        const complex* mtrxs, const bitCapInt* mtrxSkipPowers, bitLenInt mtrxSkipLen, bitCapInt mtrxSkipValueMask)
+    void UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls, bitLenInt qubitIndex,
+        const complex* mtrxs, const std::vector<bitCapInt> mtrxSkipPowers, bitCapInt mtrxSkipValueMask)
     {
-        engine->UniformlyControlledSingleBit(
-            controls, controlLen, qubitIndex, mtrxs, mtrxSkipPowers, mtrxSkipLen, mtrxSkipValueMask);
+        engine->UniformlyControlledSingleBit(controls, qubitIndex, mtrxs, mtrxSkipPowers, mtrxSkipValueMask);
     }
 
     void XMask(bitCapInt mask) { engine->XMask(mask); }
@@ -295,34 +294,34 @@ public:
     real1_f ACProb(bitLenInt control, bitLenInt target) { return engine->ACProb(control, target); }
 
     void UniformParityRZ(bitCapInt mask, real1_f angle) { engine->UniformParityRZ(mask, angle); }
-    void CUniformParityRZ(const bitLenInt* controls, bitLenInt controlLen, bitCapInt mask, real1_f angle)
+    void CUniformParityRZ(const std::vector<bitLenInt>& controls, bitCapInt mask, real1_f angle)
     {
-        engine->CUniformParityRZ(controls, controlLen, mask, angle);
+        engine->CUniformParityRZ(controls, mask, angle);
     }
 
-    void CSwap(const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2)
+    void CSwap(const std::vector<bitLenInt>& controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2)
     {
-        engine->CSwap(controls, controlLen, qubit1, qubit2);
+        engine->CSwap(controls, qubit1, qubit2);
     }
-    void AntiCSwap(const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2)
+    void AntiCSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
     {
-        engine->AntiCSwap(controls, controlLen, qubit1, qubit2);
+        engine->AntiCSwap(controls, qubit1, qubit2);
     }
-    void CSqrtSwap(const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2)
+    void CSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
     {
-        engine->CSqrtSwap(controls, controlLen, qubit1, qubit2);
+        engine->CSqrtSwap(controls, qubit1, qubit2);
     }
-    void AntiCSqrtSwap(const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2)
+    void AntiCSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
     {
-        engine->AntiCSqrtSwap(controls, controlLen, qubit1, qubit2);
+        engine->AntiCSqrtSwap(controls, qubit1, qubit2);
     }
-    void CISqrtSwap(const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2)
+    void CISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
     {
-        engine->CISqrtSwap(controls, controlLen, qubit1, qubit2);
+        engine->CISqrtSwap(controls, qubit1, qubit2);
     }
-    void AntiCISqrtSwap(const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2)
+    void AntiCISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
     {
-        engine->AntiCISqrtSwap(controls, controlLen, qubit1, qubit2);
+        engine->AntiCISqrtSwap(controls, qubit1, qubit2);
     }
 
     bool ForceM(bitLenInt qubit, bool result, bool doForce = true, bool doApply = true)
@@ -332,9 +331,9 @@ public:
 
 #if ENABLE_ALU
     void INC(bitCapInt toAdd, bitLenInt start, bitLenInt length) { engine->INC(toAdd, start, length); }
-    void CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const bitLenInt* controls, bitLenInt controlLen)
+    void CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const std::vector<bitLenInt>& controls)
     {
-        engine->CINC(toAdd, inOutStart, length, controls, controlLen);
+        engine->CINC(toAdd, inOutStart, length, controls);
     }
     void INCC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
     {
@@ -395,30 +394,30 @@ public:
     {
         engine->POWModNOut(base, modN, inStart, outStart, length);
     }
-    void CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length, const bitLenInt* controls,
-        bitLenInt controlLen)
+    void CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
+        const std::vector<bitLenInt>& controls, bitLenInt controlLen)
     {
-        engine->CMUL(toMul, inOutStart, carryStart, length, controls, controlLen);
+        engine->CMUL(toMul, inOutStart, carryStart, length, controls);
     }
-    void CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length, const bitLenInt* controls,
-        bitLenInt controlLen)
+    void CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
+        const std::vector<bitLenInt>& controls)
     {
-        engine->CDIV(toDiv, inOutStart, carryStart, length, controls, controlLen);
+        engine->CDIV(toDiv, inOutStart, carryStart, length, controls);
     }
     void CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        const bitLenInt* controls, bitLenInt controlLen)
+        const std::vector<bitLenInt>& controls)
     {
-        engine->CMULModNOut(toMul, modN, inStart, outStart, length, controls, controlLen);
+        engine->CMULModNOut(toMul, modN, inStart, outStart, length, controls);
     }
     void CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        const bitLenInt* controls, bitLenInt controlLen)
+        const std::vector<bitLenInt>& controls)
     {
-        engine->CIMULModNOut(toMul, modN, inStart, outStart, length, controls, controlLen);
+        engine->CIMULModNOut(toMul, modN, inStart, outStart, length, controls);
     }
     void CPOWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        const bitLenInt* controls, bitLenInt controlLen)
+        const std::vector<bitLenInt>& controls)
     {
-        engine->CPOWModNOut(base, modN, inStart, outStart, length, controls, controlLen);
+        engine->CPOWModNOut(base, modN, inStart, outStart, length, controls);
     }
 
     bitCapInt IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
@@ -485,9 +484,9 @@ public:
         engine->NormalizeState(nrm, norm_thresh, phaseArg);
     }
 
-    real1_f ExpectationBitsAll(const bitLenInt* bits, bitLenInt length, bitCapInt offset = 0)
+    real1_f ExpectationBitsAll(const std::vector<bitLenInt>& bits, bitCapInt offset = 0)
     {
-        return engine->ExpectationBitsAll(bits, length, offset);
+        return engine->ExpectationBitsAll(bits, offset);
     }
 
     void Finish() { engine->Finish(); }
@@ -528,13 +527,13 @@ protected:
     {
         engine->Apply2x2(offset1, offset2, mtrx, bitCount, qPowersSorted, doCalcNorm, norm_thresh);
     }
-    void ApplyControlled2x2(const bitLenInt* controls, bitLenInt controlLen, bitLenInt target, const complex* mtrx)
+    void ApplyControlled2x2(const std::vector<bitLenInt>& controls, bitLenInt target, const complex* mtrx)
     {
-        engine->ApplyControlled2x2(controls, controlLen, target, mtrx);
+        engine->ApplyControlled2x2(controls, target, mtrx);
     }
-    void ApplyAntiControlled2x2(const bitLenInt* controls, bitLenInt controlLen, bitLenInt target, const complex* mtrx)
+    void ApplyAntiControlled2x2(const std::vector<bitLenInt>& controls, bitLenInt target, const complex* mtrx)
     {
-        engine->ApplyAntiControlled2x2(controls, controlLen, target, mtrx);
+        engine->ApplyAntiControlled2x2(controls, target, mtrx);
     }
 
 #if ENABLE_ALU

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -473,7 +473,7 @@ public:
         }
 
         const complex mtrx[4U]{ topLeft, ZERO_CMPLX, ZERO_CMPLX, bottomRight };
-        MCMtrx(controls, controlLen, mtrx, target);
+        MCMtrx(controls, mtrx, target);
     }
 
     /**
@@ -484,7 +484,7 @@ public:
         const std::vector<bitLenInt>& controls, complex topRight, complex bottomLeft, bitLenInt target)
     {
         const complex mtrx[4U]{ ZERO_CMPLX, topRight, bottomLeft, ZERO_CMPLX };
-        MCMtrx(controls, controlLen, mtrx, target);
+        MCMtrx(controls, mtrx, target);
     }
 
     /**

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -1991,10 +1991,10 @@ public:
         bitLenInt start, bitLenInt length, bitCapInt result, bool doForce = true, bool doApply = true);
 
     /** Measure bits with indices in array, and return a mask of the results */
-    virtual bitCapInt M(const std::vector<bitLenInt>& bits) { return ForceM(bits, NULL); }
+    virtual bitCapInt M(const std::vector<bitLenInt>& bits) { return ForceM(bits, std::vector<bool>()); }
 
     /** Measure bits with indices in array, and return a mask of the results */
-    virtual bitCapInt ForceM(const std::vector<bitLenInt>& bits, bool const* values, bool doApply = true);
+    virtual bitCapInt ForceM(const std::vector<bitLenInt>& bits, const std::vector<bool>& values, bool doApply = true);
 
     /** Swap values of two bits in register */
     virtual void Swap(bitLenInt qubitIndex1, bitLenInt qubitIndex2);

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -1991,10 +1991,10 @@ public:
         bitLenInt start, bitLenInt length, bitCapInt result, bool doForce = true, bool doApply = true);
 
     /** Measure bits with indices in array, and return a mask of the results */
-    virtual bitCapInt M(const std::vector<bitLenInt>& bits) { return ForceM(bits, std::vector<bool>()); }
+    virtual bitCapInt M(const std::vector<bitLenInt>& bits) { return ForceM(bits, NULL); }
 
     /** Measure bits with indices in array, and return a mask of the results */
-    virtual bitCapInt ForceM(const std::vector<bitLenInt>& bits, const std::vector<bool>& values, bool doApply = true);
+    virtual bitCapInt ForceM(const std::vector<bitLenInt>& bits, bool const* values, bool doApply = true);
 
     /** Swap values of two bits in register */
     virtual void Swap(bitLenInt qubitIndex1, bitLenInt qubitIndex2);

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -256,7 +256,7 @@ public:
      *
      * \warning PSEUDO-QUANTUM
      */
-    virtual void GetProbs(std::vector<real1>& outputProbs) = 0;
+    virtual void GetProbs(real1* outputProbs) = 0;
 
     /** Get the representational amplitude of a full permutation
      *
@@ -1184,7 +1184,7 @@ public:
      * bits, there are therefore 2^k real components in "angles."
      */
     virtual void UniformlyControlledRY(
-        const std::vector<bitLenInt>& controls, bitLenInt qubitIndex, const std::vector<real1>& angles);
+        const std::vector<bitLenInt>& controls, bitLenInt qubitIndex, real1 const* angles);
 
     /**
      * Apply a "uniformly controlled" rotation of a bit around the Pauli Z axis. (See
@@ -1197,7 +1197,7 @@ public:
      * bits, there are therefore 2^k real components in "angles."
      */
     virtual void UniformlyControlledRZ(
-        const std::vector<bitLenInt>& controls, bitLenInt qubitIndex, const std::vector<real1>& angles);
+        const std::vector<bitLenInt>& controls, bitLenInt qubitIndex, real1 const* angles);
 
     /**
      * Phase shift gate
@@ -2098,7 +2098,7 @@ public:
      *
      * \warning PSEUDO-QUANTUM
      */
-    virtual void ProbMaskAll(bitCapInt mask, std::vector<real1>& probsArray);
+    virtual void ProbMaskAll(bitCapInt mask, real1* probsArray);
 
     /**
      * Direct measure of listed permutation probability
@@ -2108,7 +2108,7 @@ public:
      *
      * \warning PSEUDO-QUANTUM
      */
-    virtual void ProbBitsAll(const std::vector<bitLenInt>& bits, std::vector<real1>& probsArray);
+    virtual void ProbBitsAll(const std::vector<bitLenInt>& bits, real1* probsArray);
 
     /**
      * Get permutation expectation value of bits
@@ -2118,7 +2118,7 @@ public:
      *
      * \warning PSEUDO-QUANTUM
      */
-    virtual real1_f ExpectationBitsAll(const std::vector<bitLenInt>& bits, bitLenInt length, bitCapInt offset = 0);
+    virtual real1_f ExpectationBitsAll(const std::vector<bitLenInt>& bits, bitCapInt offset = 0);
 
     /**
      * Statistical measure of masked permutation probability

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -244,13 +244,13 @@ public:
      *
      * \warning PSEUDO-QUANTUM
      */
-    virtual void SetQuantumState(const std::vector<complex>& inputState) = 0;
+    virtual void SetQuantumState(complex const* inputState) = 0;
 
     /** Get the pure quantum state representation
      *
      * \warning PSEUDO-QUANTUM
      */
-    virtual void GetQuantumState(std::vector<complex> outputState) = 0;
+    virtual void GetQuantumState(complex* outputState) = 0;
 
     /** Get the pure quantum state representation
      *

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -420,17 +420,17 @@ public:
     /**
      * Apply an arbitrary single bit unitary transformation.
      */
-    virtual void Mtrx(const std::vector<complex>& mtrx, bitLenInt qubitIndex) = 0;
+    virtual void Mtrx(complex const* mtrx, bitLenInt qubitIndex) = 0;
 
     /**
      * Apply an arbitrary single bit unitary transformation, with arbitrary control bits.
      */
-    virtual void MCMtrx(const std::vector<bitLenInt>& controls, const std::vector<complex>& mtrx, bitLenInt target) = 0;
+    virtual void MCMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target) = 0;
 
     /**
      * Apply an arbitrary single bit unitary transformation, with arbitrary (anti-)control bits.
      */
-    virtual void MACMtrx(const std::vector<bitLenInt>& controls, const std::vector<complex>& mtrx, bitLenInt target)
+    virtual void MACMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target)
     {
         if (IS_NORM_0(mtrx[1U]) && IS_NORM_0(mtrx[2U])) {
             MACPhase(controls, mtrx[0U], mtrx[3U], target);
@@ -450,7 +450,7 @@ public:
             return;
         }
 
-        const std::vector<complex> mtrx{ topLeft, ZERO_CMPLX, ZERO_CMPLX, bottomRight };
+        const complex mtrx[4]{ topLeft, ZERO_CMPLX, ZERO_CMPLX, bottomRight };
         Mtrx(mtrx, qubitIndex);
     }
 
@@ -459,7 +459,7 @@ public:
      */
     virtual void Invert(const complex topRight, const complex bottomLeft, bitLenInt qubitIndex)
     {
-        const std::vector<complex> mtrx{ ZERO_CMPLX, topRight, bottomLeft, ZERO_CMPLX };
+        const complex mtrx[4]{ ZERO_CMPLX, topRight, bottomLeft, ZERO_CMPLX };
         Mtrx(mtrx, qubitIndex);
     }
 
@@ -472,7 +472,7 @@ public:
             return;
         }
 
-        const std::vector<complex> mtrx{ topLeft, ZERO_CMPLX, ZERO_CMPLX, bottomRight };
+        const complex mtrx[4]{ topLeft, ZERO_CMPLX, ZERO_CMPLX, bottomRight };
         MCMtrx(controls, mtrx, target);
     }
 
@@ -483,7 +483,7 @@ public:
     virtual void MCInvert(
         const std::vector<bitLenInt>& controls, complex topRight, complex bottomLeft, bitLenInt target)
     {
-        const std::vector<complex> mtrx{ ZERO_CMPLX, topRight, bottomLeft, ZERO_CMPLX };
+        const complex mtrx[4]{ ZERO_CMPLX, topRight, bottomLeft, ZERO_CMPLX };
         MCMtrx(controls, mtrx, target);
     }
 
@@ -529,12 +529,12 @@ public:
      */
 
     virtual void UniformlyControlledSingleBit(
-        const std::vector<bitLenInt>& controls, bitLenInt qubitIndex, const std::vector<complex>& mtrxs)
+        const std::vector<bitLenInt>& controls, bitLenInt qubitIndex, complex const* mtrxs)
     {
         UniformlyControlledSingleBit(controls, qubitIndex, mtrxs, std::vector<bitCapInt>(), 0);
     }
     virtual void UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls, bitLenInt qubitIndex,
-        const std::vector<complex>& mtrxs, const std::vector<bitCapInt>& mtrxSkipPowers, bitCapInt mtrxSkipValueMask);
+        complex const* mtrxs, const std::vector<bitCapInt>& mtrxSkipPowers, bitCapInt mtrxSkipValueMask);
 
     /**
      * To define a Hamiltonian, give a vector of controlled single bit gates ("HamiltonianOp" instances) that are
@@ -1271,8 +1271,8 @@ public:
      *
      * Applies \f$ e^{-i*Op} \f$, where "Op" is a 2x2 matrix, (with controls on the application of the gate).
      */
-    virtual void Exp(const std::vector<bitLenInt>& controls, bitLenInt qubit, const std::vector<complex>& matrix2x2,
-        bool antiCtrled = false);
+    virtual void Exp(
+        const std::vector<bitLenInt>& controls, bitLenInt qubit, complex const* matrix2x2, bool antiCtrled = false);
 
     /**
      * Dyadic fraction (identity) exponentiation gate

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -79,11 +79,11 @@ protected:
 
     template <typename F> void CombineAndOp(F fn, std::vector<bitLenInt> bits);
     template <typename F>
-    void CombineAndOpControlled(F fn, std::vector<bitLenInt> bits, bitLenInt const* controls, bitLenInt controlLen);
+    void CombineAndOpControlled(F fn, std::vector<bitLenInt> bits, const std::vector<bitLenInt>& controls);
 
     void ApplySingleEither(bool isInvert, complex top, complex bottom, bitLenInt target);
     void ApplyEitherControlledSingleBit(
-        bool anti, bitLenInt const* controls, bitLenInt controlLen, bitLenInt target, complex const* mtrx);
+        bool anti, const std::vector<bitLenInt>& controls, bitLenInt target, complex const* mtrx);
     void EitherISwap(bitLenInt qubit1, bitLenInt qubit2, bool isInverse);
 
     void Init();
@@ -309,17 +309,17 @@ public:
     {
         ApplySingleEither(true, topRight, bottomLeft, qubitIndex);
     }
-    void MCMtrx(bitLenInt const* controls, bitLenInt controlLen, complex const* mtrx, bitLenInt target)
+    void MCMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target)
     {
-        ApplyEitherControlledSingleBit(false, controls, controlLen, target, mtrx);
+        ApplyEitherControlledSingleBit(false, controls, target, mtrx);
     }
-    void MACMtrx(bitLenInt const* controls, bitLenInt controlLen, complex const* mtrx, bitLenInt target)
+    void MACMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target)
     {
-        ApplyEitherControlledSingleBit(true, controls, controlLen, target, mtrx);
+        ApplyEitherControlledSingleBit(true, controls, target, mtrx);
     }
 
     void UniformParityRZ(bitCapInt mask, real1_f angle);
-    void CUniformParityRZ(bitLenInt const* controls, bitLenInt controlLen, bitCapInt mask, real1_f angle);
+    void CUniformParityRZ(const std::vector<bitLenInt>& controls, bitCapInt mask, real1_f angle);
 
     void XMask(bitCapInt mask);
     void ZMask(bitCapInt mask) { PhaseParity((real1_f)PI_R1, mask); }
@@ -344,16 +344,16 @@ public:
     void MULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length);
     void IMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length);
     void POWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length);
-    void CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length, bitLenInt const* controls,
-        bitLenInt controlLen);
-    void CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length, bitLenInt const* controls,
-        bitLenInt controlLen);
+    void CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
+        const std::vector<bitLenInt>& controls);
+    void CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
+        const std::vector<bitLenInt>& controls);
     void CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        bitLenInt const* controls, bitLenInt controlLen);
+        const std::vector<bitLenInt>& controls);
     void CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        bitLenInt const* controls, bitLenInt controlLen);
+        const std::vector<bitLenInt>& controls);
     void CPOWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        bitLenInt const* controls, bitLenInt controlLen);
+        const std::vector<bitLenInt>& controls);
 
     bitCapInt IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
         const unsigned char* values, bool resetValue = true);
@@ -395,7 +395,7 @@ public:
         CombineEngines();
         return qPages[0U]->ForceMParity(mask, result, doForce);
     }
-    real1_f ExpectationBitsAll(bitLenInt const* bits, bitLenInt length, bitCapInt offset = 0);
+    real1_f ExpectationBitsAll(const std::vector<bitLenInt>& bits, bitCapInt offset = 0);
 
     void UpdateRunningNorm(real1_f norm_thresh = REAL1_DEFAULT_ARG);
     void NormalizeState(

--- a/include/qparity.hpp
+++ b/include/qparity.hpp
@@ -30,7 +30,10 @@ public:
      * If the target qubit set parity is odd, this applies a phase factor of \f$e^{i angle}\f$. If the target qubit set
      * parity is even, this applies the conjugate, e^{-i angle}.
      */
-    virtual void UniformParityRZ(bitCapInt mask, real1_f angle) { CUniformParityRZ(NULL, 0U, mask, angle); }
+    virtual void UniformParityRZ(bitCapInt mask, real1_f angle)
+    {
+        CUniformParityRZ(std::vector<bitLenInt>(), mask, angle);
+    }
 
     /** Overall probability of any odd permutation of the masked set of bits */
     virtual real1_f ProbParity(bitCapInt mask) = 0;
@@ -48,6 +51,6 @@ public:
      * If the controls are set and the target qubit set parity is even, this applies the conjugate, \f$e^{-i angle}\f$.
      * Otherwise, do nothing if any control is not set.
      */
-    virtual void CUniformParityRZ(bitLenInt const* controls, bitLenInt controlLen, bitCapInt mask, real1_f angle) = 0;
+    virtual void CUniformParityRZ(const std::vector<bitLenInt>& controls, bitCapInt mask, real1_f angle) = 0;
 };
 } // namespace Qrack

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -99,7 +99,7 @@ protected:
         });
     }
 
-    bool TrimControls(bitLenInt const* lControls, bitLenInt lControlLen, bool isAnti, std::vector<bitLenInt>& output);
+    bool TrimControls(const std::vector<bitLenInt>& lControls, bool isAnti, std::vector<bitLenInt>& output);
 
 public:
     QStabilizer(bitLenInt n, bitCapInt perm = 0U, qrack_rand_gen_ptr rgp = nullptr, complex ignored = CMPLX_DEFAULT_ARG,
@@ -426,37 +426,33 @@ public:
     void Mtrx(complex const* mtrx, bitLenInt target);
     void Phase(complex topLeft, complex bottomRight, bitLenInt target);
     void Invert(complex topRight, complex bottomLeft, bitLenInt target);
-    void MCPhase(
-        bitLenInt const* controls, bitLenInt controlLen, complex topLeft, complex bottomRight, bitLenInt target);
-    void MACPhase(
-        bitLenInt const* controls, bitLenInt controlLen, complex topLeft, complex bottomRight, bitLenInt target);
-    void MCInvert(
-        bitLenInt const* controls, bitLenInt controlLen, complex topRight, complex bottomLeft, bitLenInt target);
-    void MACInvert(
-        bitLenInt const* controls, bitLenInt controlLen, complex topRight, complex bottomLeft, bitLenInt target);
-    void MCMtrx(bitLenInt const* controls, bitLenInt controlLen, complex const* mtrx, bitLenInt target)
+    void MCPhase(const std::vector<bitLenInt>& controls, complex topLeft, complex bottomRight, bitLenInt target);
+    void MACPhase(const std::vector<bitLenInt>& controls, complex topLeft, complex bottomRight, bitLenInt target);
+    void MCInvert(const std::vector<bitLenInt>& controls, complex topRight, complex bottomLeft, bitLenInt target);
+    void MACInvert(const std::vector<bitLenInt>& controls, complex topRight, complex bottomLeft, bitLenInt target);
+    void MCMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target)
     {
         if (IS_NORM_0(mtrx[1U]) && IS_NORM_0(mtrx[2U])) {
-            MCPhase(controls, controlLen, mtrx[0U], mtrx[3U], target);
+            MCPhase(controls, mtrx[0U], mtrx[3U], target);
             return;
         }
 
         if (IS_NORM_0(mtrx[0U]) && IS_NORM_0(mtrx[3U])) {
-            MCInvert(controls, controlLen, mtrx[1U], mtrx[2U], target);
+            MCInvert(controls, mtrx[1U], mtrx[2U], target);
             return;
         }
 
         throw std::domain_error("QStabilizer::MCMtrx() not implemented for non-Clifford/Pauli cases!");
     }
-    void MACMtrx(bitLenInt const* controls, bitLenInt controlLen, complex const* mtrx, bitLenInt target)
+    void MACMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target)
     {
         if (IS_NORM_0(mtrx[1U]) && IS_NORM_0(mtrx[2U])) {
-            MACPhase(controls, controlLen, mtrx[0U], mtrx[3U], target);
+            MACPhase(controls, mtrx[0U], mtrx[3U], target);
             return;
         }
 
         if (IS_NORM_0(mtrx[0U]) && IS_NORM_0(mtrx[3U])) {
-            MACInvert(controls, controlLen, mtrx[1U], mtrx[2U], target);
+            MACInvert(controls, mtrx[1U], mtrx[2U], target);
             return;
         }
 
@@ -464,7 +460,7 @@ public:
     }
     void FSim(real1_f theta, real1_f phi, bitLenInt qubit1, bitLenInt qubit2);
 
-    bool TrySeparate(bitLenInt const* qubits, bitLenInt length, real1_f ignored);
+    bool TrySeparate(const std::vector<bitLenInt>& qubits, bitLenInt length, real1_f ignored);
     bool TrySeparate(bitLenInt qubit) { return CanDecomposeDispose(qubit, 1U); }
     bool TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
     {

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -460,7 +460,7 @@ public:
     }
     void FSim(real1_f theta, real1_f phi, bitLenInt qubit1, bitLenInt qubit2);
 
-    bool TrySeparate(const std::vector<bitLenInt>& qubits, bitLenInt length, real1_f ignored);
+    bool TrySeparate(const std::vector<bitLenInt>& qubits, real1_f ignored);
     bool TrySeparate(bitLenInt qubit) { return CanDecomposeDispose(qubit, 1U); }
     bool TrySeparate(bitLenInt qubit1, bitLenInt qubit2)
     {

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -58,8 +58,7 @@ protected:
     void FlushH(bitLenInt qubit);
     void FlushIfBlocked(bitLenInt control, bitLenInt target, bool isPhase = false);
     bool CollapseSeparableShard(bitLenInt qubit);
-    bool TrimControls(
-        bitLenInt const* lControls, bitLenInt lControlLen, std::vector<bitLenInt>& output, bool anti = false);
+    bool TrimControls(const std::vector<bitLenInt>& lControls, std::vector<bitLenInt>& output, bool anti = false);
     void CacheEigenstate(bitLenInt target);
     void FlushBuffers();
     void DumpBuffers()
@@ -275,34 +274,30 @@ public:
     bitCapInt MAll();
 
     void Mtrx(complex const* mtrx, bitLenInt target);
-    void MCMtrx(bitLenInt const* controls, bitLenInt controlLen, complex const* mtrx, bitLenInt target);
-    void MCPhase(
-        bitLenInt const* controls, bitLenInt controlLen, complex topLeft, complex bottomRight, bitLenInt target);
-    void MCInvert(
-        bitLenInt const* controls, bitLenInt controlLen, complex topRight, complex bottomLeft, bitLenInt target);
-    void MACMtrx(bitLenInt const* controls, bitLenInt controlLen, complex const* mtrx, bitLenInt target);
-    void MACPhase(
-        bitLenInt const* controls, bitLenInt controlLen, complex topLeft, complex bottomRight, bitLenInt target);
-    void MACInvert(
-        bitLenInt const* controls, bitLenInt controlLen, complex topRight, complex bottomLeft, bitLenInt target);
+    void MCMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target);
+    void MCPhase(const std::vector<bitLenInt>& controls, complex topLeft, complex bottomRight, bitLenInt target);
+    void MCInvert(const std::vector<bitLenInt>& controls, complex topRight, complex bottomLeft, bitLenInt target);
+    void MACMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target);
+    void MACPhase(const std::vector<bitLenInt>& controls, complex topLeft, complex bottomRight, bitLenInt target);
+    void MACInvert(const std::vector<bitLenInt>& controls, complex topRight, complex bottomLeft, bitLenInt target);
 
     using QInterface::UniformlyControlledSingleBit;
     void UniformlyControlledSingleBit(
-        bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubitIndex, complex const* mtrxs)
+        const std::vector<bitLenInt>& controls, bitLenInt qubitIndex, complex const* mtrxs)
     {
         if (stabilizer) {
-            QInterface::UniformlyControlledSingleBit(controls, controlLen, qubitIndex, mtrxs);
+            QInterface::UniformlyControlledSingleBit(controls, qubitIndex, mtrxs);
             return;
         }
 
-        engine->UniformlyControlledSingleBit(controls, controlLen, qubitIndex, mtrxs);
+        engine->UniformlyControlledSingleBit(controls, qubitIndex, mtrxs);
     }
 
-    void CSwap(bitLenInt const* lControls, bitLenInt lControlLen, bitLenInt qubit1, bitLenInt qubit2)
+    void CSwap(const std::vector<bitLenInt>& lControls, bitLenInt qubit1, bitLenInt qubit2)
     {
         if (stabilizer) {
             std::vector<bitLenInt> controls;
-            if (TrimControls(lControls, lControlLen, controls, false)) {
+            if (TrimControls(lControls, controls, false)) {
                 return;
             }
             if (!controls.size()) {
@@ -312,13 +307,13 @@ public:
             SwitchToEngine();
         }
 
-        engine->CSwap(lControls, lControlLen, qubit1, qubit2);
+        engine->CSwap(lControls, qubit1, qubit2);
     }
-    void CSqrtSwap(bitLenInt const* lControls, bitLenInt lControlLen, bitLenInt qubit1, bitLenInt qubit2)
+    void CSqrtSwap(const std::vector<bitLenInt>& lControls, bitLenInt qubit1, bitLenInt qubit2)
     {
         if (stabilizer) {
             std::vector<bitLenInt> controls;
-            if (TrimControls(lControls, lControlLen, controls, false)) {
+            if (TrimControls(lControls, controls, false)) {
                 return;
             }
             if (!controls.size()) {
@@ -328,13 +323,13 @@ public:
             SwitchToEngine();
         }
 
-        engine->CSqrtSwap(lControls, lControlLen, qubit1, qubit2);
+        engine->CSqrtSwap(lControls, qubit1, qubit2);
     }
-    void AntiCSqrtSwap(bitLenInt const* lControls, bitLenInt lControlLen, bitLenInt qubit1, bitLenInt qubit2)
+    void AntiCSqrtSwap(const std::vector<bitLenInt>& lControls, bitLenInt qubit1, bitLenInt qubit2)
     {
         if (stabilizer) {
             std::vector<bitLenInt> controls;
-            if (TrimControls(lControls, lControlLen, controls, true)) {
+            if (TrimControls(lControls, controls, true)) {
                 return;
             }
             if (!controls.size()) {
@@ -344,13 +339,13 @@ public:
             SwitchToEngine();
         }
 
-        engine->AntiCSqrtSwap(lControls, lControlLen, qubit1, qubit2);
+        engine->AntiCSqrtSwap(lControls, qubit1, qubit2);
     }
-    void CISqrtSwap(bitLenInt const* lControls, bitLenInt lControlLen, bitLenInt qubit1, bitLenInt qubit2)
+    void CISqrtSwap(const std::vector<bitLenInt>& lControls, bitLenInt qubit1, bitLenInt qubit2)
     {
         if (stabilizer) {
             std::vector<bitLenInt> controls;
-            if (TrimControls(lControls, lControlLen, controls, false)) {
+            if (TrimControls(lControls, controls, false)) {
                 return;
             }
             if (!controls.size()) {
@@ -360,13 +355,13 @@ public:
             SwitchToEngine();
         }
 
-        engine->CISqrtSwap(lControls, lControlLen, qubit1, qubit2);
+        engine->CISqrtSwap(lControls, qubit1, qubit2);
     }
-    void AntiCISqrtSwap(bitLenInt const* lControls, bitLenInt lControlLen, bitLenInt qubit1, bitLenInt qubit2)
+    void AntiCISqrtSwap(const std::vector<bitLenInt>& lControls, bitLenInt qubit1, bitLenInt qubit2)
     {
         if (stabilizer) {
             std::vector<bitLenInt> controls;
-            if (TrimControls(lControls, lControlLen, controls, true)) {
+            if (TrimControls(lControls, controls, true)) {
                 return;
             }
             if (!controls.size()) {
@@ -376,7 +371,7 @@ public:
             SwitchToEngine();
         }
 
-        engine->AntiCISqrtSwap(lControls, lControlLen, qubit1, qubit2);
+        engine->AntiCISqrtSwap(lControls, qubit1, qubit2);
     }
 
     void XMask(bitCapInt mask)
@@ -456,10 +451,10 @@ public:
         SwitchToEngine();
         return QINTERFACE_TO_QPARITY(engine)->ForceMParity(mask, result, doForce);
     }
-    void CUniformParityRZ(bitLenInt const* controls, bitLenInt controlLen, bitCapInt mask, real1_f angle)
+    void CUniformParityRZ(const std::vector<bitLenInt>& controls, bitCapInt mask, real1_f angle)
     {
         SwitchToEngine();
-        QINTERFACE_TO_QPARITY(engine)->CUniformParityRZ(controls, controlLen, mask, angle);
+        QINTERFACE_TO_QPARITY(engine)->CUniformParityRZ(controls, mask, angle);
     }
 
 #if ENABLE_ALU
@@ -505,14 +500,14 @@ public:
 
         engine->DECS(toSub, start, length, overflowIndex);
     }
-    void CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, bitLenInt const* controls, bitLenInt controlLen)
+    void CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const std::vector<bitLenInt>& controls)
     {
         if (stabilizer) {
-            QInterface::CINC(toAdd, inOutStart, length, controls, controlLen);
+            QInterface::CINC(toAdd, inOutStart, length, controls);
             return;
         }
 
-        engine->CINC(toAdd, inOutStart, length, controls, controlLen);
+        engine->CINC(toAdd, inOutStart, length, controls);
     }
     void INCS(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex)
     {
@@ -579,35 +574,35 @@ public:
         SwitchToEngine();
         QINTERFACE_TO_QALU(engine)->POWModNOut(base, modN, inStart, outStart, length);
     }
-    void CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length, bitLenInt const* controls,
-        bitLenInt controlLen)
+    void CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
+        const std::vector<bitLenInt>& controls)
     {
         SwitchToEngine();
-        QINTERFACE_TO_QALU(engine)->CMUL(toMul, inOutStart, carryStart, length, controls, controlLen);
+        QINTERFACE_TO_QALU(engine)->CMUL(toMul, inOutStart, carryStart, length, controls);
     }
-    void CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length, bitLenInt const* controls,
-        bitLenInt controlLen)
+    void CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
+        const std::vector<bitLenInt>& controls)
     {
         SwitchToEngine();
-        QINTERFACE_TO_QALU(engine)->CDIV(toDiv, inOutStart, carryStart, length, controls, controlLen);
+        QINTERFACE_TO_QALU(engine)->CDIV(toDiv, inOutStart, carryStart, length, controls);
     }
     void CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        bitLenInt const* controls, bitLenInt controlLen)
+        const std::vector<bitLenInt>& controls)
     {
         SwitchToEngine();
-        QINTERFACE_TO_QALU(engine)->CMULModNOut(toMul, modN, inStart, outStart, length, controls, controlLen);
+        QINTERFACE_TO_QALU(engine)->CMULModNOut(toMul, modN, inStart, outStart, length, controls);
     }
     void CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        bitLenInt const* controls, bitLenInt controlLen)
+        const std::vector<bitLenInt>& controls)
     {
         SwitchToEngine();
-        QINTERFACE_TO_QALU(engine)->CIMULModNOut(toMul, modN, inStart, outStart, length, controls, controlLen);
+        QINTERFACE_TO_QALU(engine)->CIMULModNOut(toMul, modN, inStart, outStart, length, controls);
     }
     void CPOWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        bitLenInt const* controls, bitLenInt controlLen)
+        const std::vector<bitLenInt>& controls)
     {
         SwitchToEngine();
-        QINTERFACE_TO_QALU(engine)->CPOWModNOut(base, modN, inStart, outStart, length, controls, controlLen);
+        QINTERFACE_TO_QALU(engine)->CPOWModNOut(base, modN, inStart, outStart, length, controls);
     }
 
     bitCapInt IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
@@ -704,18 +699,18 @@ public:
     void NormalizeState(
         real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1_F);
 
-    real1_f ExpectationBitsAll(bitLenInt const* bits, bitLenInt length, bitCapInt offset = 0)
+    real1_f ExpectationBitsAll(const std::vector<bitLenInt>& bits, bitCapInt offset = 0)
     {
         if (stabilizer) {
-            return QInterface::ExpectationBitsAll(bits, length, offset);
+            return QInterface::ExpectationBitsAll(bits, offset);
         }
 
-        return engine->ExpectationBitsAll(bits, length, offset);
+        return engine->ExpectationBitsAll(bits, offset);
     }
 
     bool TrySeparate(bitLenInt qubit);
     bool TrySeparate(bitLenInt qubit1, bitLenInt qubit2);
-    bool TrySeparate(bitLenInt const* qubits, bitLenInt length, real1_f error_tol);
+    bool TrySeparate(const std::vector<bitLenInt>& qubits, real1_f error_tol);
 
     QInterfacePtr Clone();
 

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -419,9 +419,8 @@ public:
         }
     }
 
-    std::map<bitCapInt, int> MultiShotMeasureMask(bitCapInt const* qPowers, bitLenInt qPowerCount, unsigned shots);
-    void MultiShotMeasureMask(
-        bitCapInt const* qPowers, bitLenInt qPowerCount, unsigned shots, unsigned long long* shotsArray);
+    std::map<bitCapInt, int> MultiShotMeasureMask(const std::vector<bitCapInt>& qPowers, unsigned shots);
+    void MultiShotMeasureMask(const std::vector<bitCapInt>& qPowers, unsigned shots, unsigned long long* shotsArray);
 
     real1_f ProbParity(bitCapInt mask)
     {

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -137,36 +137,35 @@ public:
     virtual void Phase(complex topLeft, complex bottomRight, bitLenInt qubitIndex);
     virtual void Invert(complex topRight, complex bottomLeft, bitLenInt qubitIndex);
     virtual void MCPhase(
-        bitLenInt const* controls, bitLenInt controlLen, complex topLeft, complex bottomRight, bitLenInt target);
+        const std::vector<bitLenInt>& controls, complex topLeft, complex bottomRight, bitLenInt target);
     virtual void MCInvert(
-        bitLenInt const* controls, bitLenInt controlLen, complex topRight, complex bottomLeft, bitLenInt target);
+        const std::vector<bitLenInt>& controls, complex topRight, complex bottomLeft, bitLenInt target);
     virtual void MACPhase(
-        bitLenInt const* controls, bitLenInt controlLen, complex topLeft, complex bottomRight, bitLenInt target);
+        const std::vector<bitLenInt>& controls, complex topLeft, complex bottomRight, bitLenInt target);
     virtual void MACInvert(
-        bitLenInt const* controls, bitLenInt controlLen, complex topRight, complex bottomLeft, bitLenInt target);
+        const std::vector<bitLenInt>& controls, complex topRight, complex bottomLeft, bitLenInt target);
     virtual void Mtrx(complex const* mtrx, bitLenInt qubit);
-    virtual void MCMtrx(bitLenInt const* controls, bitLenInt controlLen, complex const* mtrx, bitLenInt target);
-    virtual void MACMtrx(bitLenInt const* controls, bitLenInt controlLen, complex const* mtrx, bitLenInt target);
+    virtual void MCMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target);
+    virtual void MACMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target);
     using QInterface::UniformlyControlledSingleBit;
-    virtual void UniformlyControlledSingleBit(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubitIndex,
-        complex const* mtrxs, bitCapInt const* mtrxSkipPowers, bitLenInt mtrxSkipLen, bitCapInt mtrxSkipValueMask);
-    virtual void CUniformParityRZ(bitLenInt const* controls, bitLenInt controlLen, bitCapInt mask, real1_f angle);
-    virtual void CSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2);
-    virtual void AntiCSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2);
-    virtual void CSqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2);
-    virtual void AntiCSqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2);
-    virtual void CISqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2);
-    virtual void AntiCISqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2);
+    virtual void UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls, bitLenInt qubitIndex,
+        complex const* mtrxs, const std::vector<bitCapInt>& mtrxSkipPowers, bitCapInt mtrxSkipValueMask);
+    virtual void CUniformParityRZ(const std::vector<bitLenInt>& controls, bitCapInt mask, real1_f angle);
+    virtual void CSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2);
+    virtual void AntiCSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2);
+    virtual void CSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2);
+    virtual void AntiCSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2);
+    virtual void CISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2);
+    virtual void AntiCISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2);
     using QInterface::ForceM;
     virtual bool ForceM(bitLenInt qubitIndex, bool result, bool doForce = true, bool doApply = true);
     using QInterface::ForceMReg;
     virtual bitCapInt ForceMReg(
         bitLenInt start, bitLenInt length, bitCapInt result, bool doForce = true, bool doApply = true);
     virtual bitCapInt MAll();
-    virtual std::map<bitCapInt, int> MultiShotMeasureMask(
-        bitCapInt const* qPowers, bitLenInt qPowerCount, unsigned shots);
+    virtual std::map<bitCapInt, int> MultiShotMeasureMask(const std::vector<bitCapInt>& qPowers, unsigned shots);
     virtual void MultiShotMeasureMask(
-        bitCapInt const* qPowers, bitLenInt qPowerCount, unsigned shots, unsigned long long* shotsArray);
+        const std::vector<bitCapInt>& qPowers, unsigned shots, unsigned long long* shotsArray);
 
     /** @} */
 
@@ -187,10 +186,9 @@ public:
     {
         QInterface::DECS(toSub, start, length, overflowIndex);
     }
-    virtual void CDEC(
-        bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, bitLenInt const* controls, bitLenInt controlLen)
+    virtual void CDEC(bitCapInt toSub, bitLenInt inOutStart, bitLenInt length, const std::vector<bitLenInt>& controls)
     {
-        QInterface::CDEC(toSub, inOutStart, length, controls, controlLen);
+        QInterface::CDEC(toSub, inOutStart, length, controls);
     }
     virtual void INCDECC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
     {
@@ -205,19 +203,18 @@ public:
         QInterface::IMULModNOut(toMul, modN, inStart, outStart, length);
     }
     virtual void CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        bitLenInt const* controls, bitLenInt controlLen)
+        const std::vector<bitLenInt>& controls)
     {
-        QInterface::CMULModNOut(toMul, modN, inStart, outStart, length, controls, controlLen);
+        QInterface::CMULModNOut(toMul, modN, inStart, outStart, length, controls);
     }
     virtual void CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        bitLenInt const* controls, bitLenInt controlLen)
+        const std::vector<bitLenInt>& controls)
     {
-        QInterface::CIMULModNOut(toMul, modN, inStart, outStart, length, controls, controlLen);
+        QInterface::CIMULModNOut(toMul, modN, inStart, outStart, length, controls);
     }
 
     virtual void INC(bitCapInt toAdd, bitLenInt start, bitLenInt length);
-    virtual void CINC(
-        bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, bitLenInt const* controls, bitLenInt controlLen);
+    virtual void CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const std::vector<bitLenInt>& controls);
     virtual void INCC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex);
     virtual void INCS(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex);
     virtual void INCDECSC(
@@ -233,11 +230,11 @@ public:
     virtual void DIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length);
     virtual void POWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length);
     virtual void CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
-        bitLenInt const* controls, bitLenInt controlLen);
+        const std::vector<bitLenInt>& controls);
     virtual void CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
-        bitLenInt const* controls, bitLenInt controlLen);
+        const std::vector<bitLenInt>& controls);
     virtual void CPOWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-        bitLenInt const* controls, bitLenInt controlLen);
+        const std::vector<bitLenInt>& controls);
     virtual bitCapInt IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
         bitLenInt valueLength, const unsigned char* values, bool resetValue = true);
     virtual bitCapInt IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart,
@@ -281,7 +278,7 @@ public:
     {
         return SumSqrDiff(std::dynamic_pointer_cast<QUnit>(toCompare));
     }
-    virtual real1_f ExpectationBitsAll(bitLenInt const* bits, bitLenInt length, bitCapInt offset = 0);
+    virtual real1_f ExpectationBitsAll(const std::vector<bitLenInt>& bits, bitCapInt offset = 0);
 
     virtual real1_f SumSqrDiff(QUnitPtr toCompare);
     virtual void UpdateRunningNorm(real1_f norm_thresh = REAL1_DEFAULT_ARG);
@@ -298,7 +295,7 @@ public:
     using QInterface::isClifford;
     virtual bool isClifford(bitLenInt qubit) { return shards[qubit].isClifford(); };
 
-    virtual bool TrySeparate(bitLenInt const* qubits, bitLenInt length, real1_f error_tol);
+    virtual bool TrySeparate(const std::vector<bitLenInt>& qubits, real1_f error_tol);
     virtual bool TrySeparate(bitLenInt qubit);
     virtual bool TrySeparate(bitLenInt qubit1, bitLenInt qubit2);
 
@@ -322,9 +319,9 @@ protected:
     typedef void (QAlu::*INCxFn)(bitCapInt, bitLenInt, bitLenInt, bitLenInt);
     typedef void (QAlu::*INCxxFn)(bitCapInt, bitLenInt, bitLenInt, bitLenInt, bitLenInt);
     typedef void (QAlu::*CMULFn)(bitCapInt toMod, bitLenInt start, bitLenInt carryStart, bitLenInt length,
-        bitLenInt const* controls, bitLenInt controlLen);
+        const std::vector<bitLenInt>& controls);
     typedef void (QAlu::*CMULModFn)(bitCapInt toMod, bitCapInt modN, bitLenInt start, bitLenInt carryStart,
-        bitLenInt length, bitLenInt const* controls, bitLenInt controlLen);
+        bitLenInt length, const std::vector<bitLenInt>& controls);
     void INT(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt carryIndex, bool hasCarry,
         std::vector<bitLenInt> controlVec = std::vector<bitLenInt>());
     void INTS(bitCapInt toMod, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex,
@@ -366,7 +363,7 @@ protected:
 
     virtual bool CheckBitsPermutation(bitLenInt start, bitLenInt length = 1);
     virtual bitCapInt GetCachedPermutation(bitLenInt start, bitLenInt length);
-    virtual bitCapInt GetCachedPermutation(bitLenInt const* bitArray, bitLenInt length);
+    virtual bitCapInt GetCachedPermutation(const std::vector<bitLenInt>& bitArray);
     virtual bool CheckBitsPlus(bitLenInt qubitIndex, bitLenInt length);
 
     virtual QInterfacePtr EntangleInCurrentBasis(
@@ -390,7 +387,7 @@ protected:
     };
     void SortUnit(QInterfacePtr unit, std::vector<QSortEntry>& bits, bitLenInt low, bitLenInt high);
 
-    bool TrimControls(bitLenInt const* controls, bitLenInt controlLen, std::vector<bitLenInt>& output, bool anti);
+    bool TrimControls(const std::vector<bitLenInt>& controls, std::vector<bitLenInt>& output, bool anti);
 
     template <typename CF>
     void ApplyEitherControlled(

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -106,7 +106,7 @@ public:
 
     void clear() { std::fill(amplitudes.get(), amplitudes.get() + (bitCapIntOcl)capacity, ZERO_CMPLX); }
 
-    void copy_in(const complex* copyIn)
+    void copy_in(complex const* copyIn)
     {
         if (copyIn) {
             std::copy(copyIn, copyIn + (bitCapIntOcl)capacity, amplitudes.get());
@@ -115,7 +115,7 @@ public:
         }
     }
 
-    void copy_in(const complex* copyIn, const bitCapIntOcl offset, const bitCapIntOcl length)
+    void copy_in(complex const* copyIn, const bitCapIntOcl offset, const bitCapIntOcl length)
     {
         if (copyIn) {
             std::copy(copyIn, copyIn + length, amplitudes.get() + offset);
@@ -128,7 +128,7 @@ public:
         StateVectorPtr copyInSv, const bitCapIntOcl srcOffset, const bitCapIntOcl dstOffset, const bitCapIntOcl length)
     {
         if (copyInSv) {
-            const complex* copyIn = std::dynamic_pointer_cast<StateVectorArray>(copyInSv)->amplitudes.get() + srcOffset;
+            complex const* copyIn = std::dynamic_pointer_cast<StateVectorArray>(copyInSv)->amplitudes.get() + srcOffset;
             std::copy(copyIn, copyIn + length, amplitudes.get() + dstOffset);
         } else {
             std::fill(amplitudes.get() + dstOffset, amplitudes.get() + dstOffset + length, ZERO_CMPLX);
@@ -247,7 +247,7 @@ public:
         amplitudes.clear();
     }
 
-    void copy_in(const complex* copyIn)
+    void copy_in(complex const* copyIn)
     {
         if (!copyIn) {
             clear();
@@ -264,7 +264,7 @@ public:
         }
     }
 
-    void copy_in(const complex* copyIn, const bitCapIntOcl offset, const bitCapIntOcl length)
+    void copy_in(complex const* copyIn, const bitCapIntOcl offset, const bitCapIntOcl length)
     {
         if (!copyIn) {
             std::lock_guard<std::mutex> lock(mtx);

--- a/src/common/functions.cpp
+++ b/src/common/functions.cpp
@@ -78,7 +78,7 @@ _INTPOW(bitCapInt, intPow)
 _INTPOW(bitCapIntOcl, intPowOcl)
 
 #if ENABLE_COMPLEX_X2
-void mul2x2(const complex* left, const complex* right, complex* out)
+void mul2x2(complex const* left, complex const* right, complex* out)
 {
     const complex2 left0(left[0U], left[2U]);
     const complex2 left1(left[1U], left[3U]);
@@ -92,7 +92,7 @@ void mul2x2(const complex* left, const complex* right, complex* out)
     out[3U] = col.c[1U];
 }
 #else
-void mul2x2(const complex* left, const complex* right, complex* out)
+void mul2x2(complex const* left, complex const* right, complex* out)
 {
     out[0U] = (left[0U] * right[0U]) + (left[1U] * right[2U]);
     out[1U] = (left[0U] * right[1U]) + (left[1U] * right[3U]);
@@ -101,7 +101,7 @@ void mul2x2(const complex* left, const complex* right, complex* out)
 }
 #endif
 
-void _expLog2x2(const complex* matrix2x2, complex* outMatrix2x2, bool isExp)
+void _expLog2x2(complex const* matrix2x2, complex* outMatrix2x2, bool isExp)
 {
     // Solve for the eigenvalues and eigenvectors of a 2x2 matrix, diagonalize, exponentiate, return to the original
     // basis, and apply.
@@ -182,11 +182,11 @@ void _expLog2x2(const complex* matrix2x2, complex* outMatrix2x2, bool isExp)
     std::copy(expOfGate, expOfGate + 4U, outMatrix2x2);
 }
 
-void exp2x2(const complex* matrix2x2, complex* outMatrix2x2) { _expLog2x2(matrix2x2, outMatrix2x2, true); }
+void exp2x2(complex const* matrix2x2, complex* outMatrix2x2) { _expLog2x2(matrix2x2, outMatrix2x2, true); }
 
-void log2x2(const complex* matrix2x2, complex* outMatrix2x2) { _expLog2x2(matrix2x2, outMatrix2x2, false); }
+void log2x2(complex const* matrix2x2, complex* outMatrix2x2) { _expLog2x2(matrix2x2, outMatrix2x2, false); }
 
-void inv2x2(const complex* matrix2x2, complex* outMatrix2x2)
+void inv2x2(complex const* matrix2x2, complex* outMatrix2x2)
 {
     const complex det = ONE_CMPLX / (matrix2x2[0U] * matrix2x2[3U] - matrix2x2[1U] * matrix2x2[2U]);
     outMatrix2x2[0U] = det * matrix2x2[3U];

--- a/src/common/functions.cpp
+++ b/src/common/functions.cpp
@@ -235,15 +235,15 @@ bool isOverflowSub(bitCapInt inOutInt, bitCapInt inInt, const bitCapInt& signMas
     return false;
 }
 
-bitCapInt pushApartBits(const bitCapInt& perm, const bitCapInt* skipPowers, const bitLenInt skipPowersCount)
+bitCapInt pushApartBits(const bitCapInt& perm, const std::vector<bitCapInt>& skipPowers)
 {
-    if (!skipPowersCount) {
+    if (!skipPowers.size()) {
         return perm;
     }
 
     bitCapInt iHigh = perm;
     bitCapInt i = 0U;
-    for (bitCapIntOcl p = 0U; p < skipPowersCount; ++p) {
+    for (bitCapIntOcl p = 0U; p < skipPowers.size(); ++p) {
         bitCapInt iLow = iHigh & (skipPowers[p] - ONE_BCI);
         i |= iLow;
         iHigh = (iHigh ^ iLow) << ONE_BCI;

--- a/src/common/parallel_for.cpp
+++ b/src/common/parallel_for.cpp
@@ -127,9 +127,10 @@ void ParallelFor::par_for_skip(const bitCapIntOcl begin, const bitCapIntOcl end,
     par_for_inc(begin, (end - begin) >> maskWidth, incFn, fn);
 }
 
-void ParallelFor::par_for_mask(const bitCapIntOcl begin, const bitCapIntOcl end, const bitCapIntOcl* maskArray,
-    const bitLenInt maskLen, ParallelFunc fn)
+void ParallelFor::par_for_mask(
+    const bitCapIntOcl begin, const bitCapIntOcl end, const std::vector<bitCapIntOcl>& maskArray, ParallelFunc fn)
 {
+    const bitLenInt maskLen = maskArray.size();
     /* Pre-calculate the masks to simplify the increment function later. */
     std::unique_ptr<bitCapIntOcl[][2]> masks(new bitCapIntOcl[maskLen][2]);
 

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -167,14 +167,14 @@ void RHelper(uintq sid, uintq b, double phi, uintq q)
 void MCRHelper(uintq sid, uintq b, double phi, uintq n, uintq* c, uintq q)
 {
     QInterfacePtr simulator = simulators[sid];
-    std::unique_ptr<bitLenInt[]> ctrlsArray(new bitLenInt[n]);
+    std::vector<bitLenInt> ctrlsArray(n);
     for (uintq i = 0U; i < n; ++i) {
         ctrlsArray[i] = shards[simulator.get()][c[i]];
     }
 
     if (b == PauliI) {
         complex phaseFac = exp(complex(ZERO_R1, (real1)(phi / 4)));
-        simulator->MCPhase(ctrlsArray.get(), n, phaseFac, phaseFac, shards[simulator.get()][q]);
+        simulator->MCPhase(ctrlsArray, phaseFac, phaseFac, shards[simulator.get()][q]);
         return;
     }
 
@@ -188,18 +188,17 @@ void MCRHelper(uintq sid, uintq b, double phi, uintq n, uintq* c, uintq q)
         pauliR[1U] = complex(ZERO_R1, -sine);
         pauliR[2U] = complex(ZERO_R1, -sine);
         pauliR[3U] = complex(cosine, ZERO_R1);
-        simulator->MCMtrx(ctrlsArray.get(), n, pauliR, shards[simulator.get()][q]);
+        simulator->MCMtrx(ctrlsArray, pauliR, shards[simulator.get()][q]);
         break;
     case PauliY:
         pauliR[0U] = complex(cosine, ZERO_R1);
         pauliR[1U] = complex(-sine, ZERO_R1);
         pauliR[2U] = complex(sine, ZERO_R1);
         pauliR[3U] = complex(cosine, ZERO_R1);
-        simulator->MCMtrx(ctrlsArray.get(), n, pauliR, shards[simulator.get()][q]);
+        simulator->MCMtrx(ctrlsArray, pauliR, shards[simulator.get()][q]);
         break;
     case PauliZ:
-        simulator->MCPhase(
-            ctrlsArray.get(), n, complex(cosine, -sine), complex(cosine, sine), shards[simulator.get()][q]);
+        simulator->MCPhase(ctrlsArray, complex(cosine, -sine), complex(cosine, sine), shards[simulator.get()][q]);
         break;
     case PauliI:
     default:
@@ -1106,7 +1105,7 @@ MICROSOFT_QUANTUM_DECL void Mtrx(_In_ uintq sid, _In_reads_(8) double* m, _In_ u
 #define MAP_CONTROLS_AND_LOCK(sid, numC)                                                                               \
     SIMULATOR_LOCK_GUARD(sid)                                                                                          \
     QInterfacePtr simulator = simulators[sid];                                                                         \
-    std::unique_ptr<bitLenInt[]> ctrlsArray(new bitLenInt[numC]);                                                      \
+    std::vector<bitLenInt> ctrlsArray(numC);                                                                           \
     for (uintq i = 0; i < numC; ++i) {                                                                                 \
         ctrlsArray[i] = shards[simulator.get()][c[i]];                                                                 \
     }
@@ -1118,7 +1117,7 @@ MICROSOFT_QUANTUM_DECL void MCX(_In_ uintq sid, _In_ uintq n, _In_reads_(n) uint
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->MCInvert(ctrlsArray.get(), n, ONE_CMPLX, ONE_CMPLX, shards[simulator.get()][q]);
+        simulator->MCInvert(ctrlsArray, ONE_CMPLX, ONE_CMPLX, shards[simulator.get()][q]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1132,7 +1131,7 @@ MICROSOFT_QUANTUM_DECL void MCY(_In_ uintq sid, _In_ uintq n, _In_reads_(n) uint
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->MCInvert(ctrlsArray.get(), n, -I_CMPLX, I_CMPLX, shards[simulator.get()][q]);
+        simulator->MCInvert(ctrlsArray, -I_CMPLX, I_CMPLX, shards[simulator.get()][q]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1146,7 +1145,7 @@ MICROSOFT_QUANTUM_DECL void MCZ(_In_ uintq sid, _In_ uintq n, _In_reads_(n) uint
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->MCPhase(ctrlsArray.get(), n, ONE_CMPLX, -ONE_CMPLX, shards[simulator.get()][q]);
+        simulator->MCPhase(ctrlsArray, ONE_CMPLX, -ONE_CMPLX, shards[simulator.get()][q]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1163,7 +1162,7 @@ MICROSOFT_QUANTUM_DECL void MCH(_In_ uintq sid, _In_ uintq n, _In_reads_(n) uint
 
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->MCMtrx(ctrlsArray.get(), n, hGate, shards[simulator.get()][q]);
+        simulator->MCMtrx(ctrlsArray, hGate, shards[simulator.get()][q]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1177,7 +1176,7 @@ MICROSOFT_QUANTUM_DECL void MCS(_In_ uintq sid, _In_ uintq n, _In_reads_(n) uint
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->MCPhase(ctrlsArray.get(), n, ONE_CMPLX, I_CMPLX, shards[simulator.get()][q]);
+        simulator->MCPhase(ctrlsArray, ONE_CMPLX, I_CMPLX, shards[simulator.get()][q]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1191,7 +1190,7 @@ MICROSOFT_QUANTUM_DECL void MCT(_In_ uintq sid, _In_ uintq n, _In_reads_(n) uint
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->MCPhase(ctrlsArray.get(), n, ONE_CMPLX, complex(SQRT1_2_R1, SQRT1_2_R1), shards[simulator.get()][q]);
+        simulator->MCPhase(ctrlsArray, ONE_CMPLX, complex(SQRT1_2_R1, SQRT1_2_R1), shards[simulator.get()][q]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1205,7 +1204,7 @@ MICROSOFT_QUANTUM_DECL void MCAdjS(_In_ uintq sid, _In_ uintq n, _In_reads_(n) u
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->MCPhase(ctrlsArray.get(), n, ONE_CMPLX, -I_CMPLX, shards[simulator.get()][q]);
+        simulator->MCPhase(ctrlsArray, ONE_CMPLX, -I_CMPLX, shards[simulator.get()][q]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1219,8 +1218,7 @@ MICROSOFT_QUANTUM_DECL void MCAdjT(_In_ uintq sid, _In_ uintq n, _In_reads_(n) u
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->MCPhase(
-            ctrlsArray.get(), n, ONE_CMPLX, complex(SQRT1_2_R1, -SQRT1_2_R1), shards[simulator.get()][q]);
+        simulator->MCPhase(ctrlsArray, ONE_CMPLX, complex(SQRT1_2_R1, -SQRT1_2_R1), shards[simulator.get()][q]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1235,7 +1233,7 @@ MICROSOFT_QUANTUM_DECL void MCU(_In_ uintq sid, _In_ uintq n, _In_reads_(n) uint
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->CU(ctrlsArray.get(), n, shards[simulator.get()][q], (real1_f)theta, (real1_f)phi, (real1_f)lambda);
+        simulator->CU(ctrlsArray, shards[simulator.get()][q], (real1_f)theta, (real1_f)phi, (real1_f)lambda);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1253,7 +1251,7 @@ MICROSOFT_QUANTUM_DECL void MCMtrx(
 
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->MCMtrx(ctrlsArray.get(), n, mtrx, shards[simulator.get()][q]);
+        simulator->MCMtrx(ctrlsArray, mtrx, shards[simulator.get()][q]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1267,7 +1265,7 @@ MICROSOFT_QUANTUM_DECL void MACX(_In_ uintq sid, _In_ uintq n, _In_reads_(n) uin
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->MACInvert(ctrlsArray.get(), n, ONE_CMPLX, ONE_CMPLX, shards[simulator.get()][q]);
+        simulator->MACInvert(ctrlsArray, ONE_CMPLX, ONE_CMPLX, shards[simulator.get()][q]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1281,7 +1279,7 @@ MICROSOFT_QUANTUM_DECL void MACY(_In_ uintq sid, _In_ uintq n, _In_reads_(n) uin
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->MACInvert(ctrlsArray.get(), n, -I_CMPLX, I_CMPLX, shards[simulator.get()][q]);
+        simulator->MACInvert(ctrlsArray, -I_CMPLX, I_CMPLX, shards[simulator.get()][q]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1295,7 +1293,7 @@ MICROSOFT_QUANTUM_DECL void MACZ(_In_ uintq sid, _In_ uintq n, _In_reads_(n) uin
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->MACPhase(ctrlsArray.get(), n, ONE_CMPLX, -ONE_CMPLX, shards[simulator.get()][q]);
+        simulator->MACPhase(ctrlsArray, ONE_CMPLX, -ONE_CMPLX, shards[simulator.get()][q]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1312,7 +1310,7 @@ MICROSOFT_QUANTUM_DECL void MACH(_In_ uintq sid, _In_ uintq n, _In_reads_(n) uin
 
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->MACMtrx(ctrlsArray.get(), n, hGate, shards[simulator.get()][q]);
+        simulator->MACMtrx(ctrlsArray, hGate, shards[simulator.get()][q]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1326,7 +1324,7 @@ MICROSOFT_QUANTUM_DECL void MACS(_In_ uintq sid, _In_ uintq n, _In_reads_(n) uin
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->MACPhase(ctrlsArray.get(), n, ONE_CMPLX, I_CMPLX, shards[simulator.get()][q]);
+        simulator->MACPhase(ctrlsArray, ONE_CMPLX, I_CMPLX, shards[simulator.get()][q]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1340,8 +1338,7 @@ MICROSOFT_QUANTUM_DECL void MACT(_In_ uintq sid, _In_ uintq n, _In_reads_(n) uin
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->MACPhase(
-            ctrlsArray.get(), n, ONE_CMPLX, complex(SQRT1_2_R1, SQRT1_2_R1), shards[simulator.get()][q]);
+        simulator->MACPhase(ctrlsArray, ONE_CMPLX, complex(SQRT1_2_R1, SQRT1_2_R1), shards[simulator.get()][q]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1355,7 +1352,7 @@ MICROSOFT_QUANTUM_DECL void MACAdjS(_In_ uintq sid, _In_ uintq n, _In_reads_(n) 
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->MACPhase(ctrlsArray.get(), n, ONE_CMPLX, -I_CMPLX, shards[simulator.get()][q]);
+        simulator->MACPhase(ctrlsArray, ONE_CMPLX, -I_CMPLX, shards[simulator.get()][q]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1369,8 +1366,7 @@ MICROSOFT_QUANTUM_DECL void MACAdjT(_In_ uintq sid, _In_ uintq n, _In_reads_(n) 
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->MACPhase(
-            ctrlsArray.get(), n, ONE_CMPLX, complex(SQRT1_2_R1, -SQRT1_2_R1), shards[simulator.get()][q]);
+        simulator->MACPhase(ctrlsArray, ONE_CMPLX, complex(SQRT1_2_R1, -SQRT1_2_R1), shards[simulator.get()][q]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1385,8 +1381,7 @@ MICROSOFT_QUANTUM_DECL void MACU(_In_ uintq sid, _In_ uintq n, _In_reads_(n) uin
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->AntiCU(
-            ctrlsArray.get(), n, shards[simulator.get()][q], (real1_f)theta, (real1_f)phi, (real1_f)lambda);
+        simulator->AntiCU(ctrlsArray, shards[simulator.get()][q], (real1_f)theta, (real1_f)phi, (real1_f)lambda);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1404,7 +1399,7 @@ MICROSOFT_QUANTUM_DECL void MACMtrx(
 
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->MACMtrx(ctrlsArray.get(), n, mtrx, shards[simulator.get()][q]);
+        simulator->MACMtrx(ctrlsArray, mtrx, shards[simulator.get()][q]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1420,7 +1415,7 @@ MICROSOFT_QUANTUM_DECL void Multiplex1Mtrx(
 
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->UniformlyControlledSingleBit(ctrlsArray.get(), n, shards[simulator.get()][q], mtrxs.get());
+        simulator->UniformlyControlledSingleBit(ctrlsArray, shards[simulator.get()][q], mtrxs.get());
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1579,7 +1574,7 @@ MICROSOFT_QUANTUM_DECL void MCExp(_In_ uintq sid, _In_ uintq n, _In_reads_(n) in
             TransformPauliBasis(simulator, n, b, q);
 
             std::size_t mask = make_mask(qVec);
-            QPARITY(simulator)->CUniformParityRZ(&(csVec[0]), csVec.size(), (bitCapInt)mask, (real1_f)(-phi));
+            QPARITY(simulator)->CUniformParityRZ(csVec, (bitCapInt)mask, (real1_f)(-phi));
 
             RevertPauliBasis(simulator, n, b, q);
         }
@@ -1668,13 +1663,13 @@ MICROSOFT_QUANTUM_DECL void MeasureShots(
     SIMULATOR_LOCK_GUARD(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    std::unique_ptr<bitCapInt[]> qPowers(new bitCapInt[n]);
+    std::vector<bitCapInt> qPowers(n);
     for (uintq i = 0U; i < n; ++i) {
         qPowers[i] = Qrack::pow2(shards[simulator.get()][q[i]]);
     }
 
     try {
-        simulator->MultiShotMeasureMask(qPowers.get(), n, (unsigned)s, m);
+        simulator->MultiShotMeasureMask(qPowers, (unsigned)s, m);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1737,7 +1732,7 @@ MICROSOFT_QUANTUM_DECL void CSWAP(_In_ uintq sid, _In_ uintq n, _In_reads_(n) ui
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->CSwap(ctrlsArray.get(), n, shards[simulator.get()][qi1], shards[simulator.get()][qi2]);
+        simulator->CSwap(ctrlsArray, shards[simulator.get()][qi1], shards[simulator.get()][qi2]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -1748,7 +1743,7 @@ MICROSOFT_QUANTUM_DECL void ACSWAP(_In_ uintq sid, _In_ uintq n, _In_reads_(n) u
 {
     MAP_CONTROLS_AND_LOCK(sid, n)
     try {
-        simulator->AntiCSwap(ctrlsArray.get(), n, shards[simulator.get()][qi1], shards[simulator.get()][qi2]);
+        simulator->AntiCSwap(ctrlsArray, shards[simulator.get()][qi1], shards[simulator.get()][qi2]);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -2041,12 +2036,14 @@ MICROSOFT_QUANTUM_DECL double PermutationExpectation(_In_ uintq sid, _In_ uintq 
 {
     SIMULATOR_LOCK_GUARD_DOUBLE(sid)
 
-    std::unique_ptr<bitLenInt[]> q(new bitLenInt[n]);
-    std::copy(c, c + n, q.get());
+    std::vector<bitLenInt> q(n);
+    for (uintq i = 0U; i < n; ++i) {
+        q[i] = shards[simulators[sid].get()][c[i]];
+    }
 
     try {
         QInterfacePtr simulator = simulators[sid];
-        return (double)simulator->ExpectationBitsAll(q.get(), n);
+        return (double)simulator->ExpectationBitsAll(q);
     } catch (...) {
         simulatorErrors[sid] = 1;
         return (double)REAL1_DEFAULT_ARG;
@@ -2062,9 +2059,11 @@ MICROSOFT_QUANTUM_DECL void QFT(_In_ uintq sid, _In_ uintq n, _In_reads_(n) uint
 #if QBCAPPOW >= 32
         simulator->QFTR(c, n);
 #else
-        std::unique_ptr<bitLenInt[]> q(new bitLenInt[n]);
-        std::copy(c, c + n, q.get());
-        simulator->QFTR(q.get(), n);
+        std::vector<bitLenInt> q(n);
+        for (uintq i = 0U; i < n; ++i) {
+            q[i] = shards[simulators[sid].get()][c[i]];
+        }
+        simulator->QFTR(q);
 #endif
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
@@ -2080,9 +2079,11 @@ MICROSOFT_QUANTUM_DECL void IQFT(_In_ uintq sid, _In_ uintq n, _In_reads_(n) uin
 #if QBCAPPOW >= 32
         simulator->IQFTR(c, n);
 #else
-        std::unique_ptr<bitLenInt[]> q(new bitLenInt[n]);
-        std::copy(c, c + n, q.get());
-        simulator->IQFTR(q.get(), n);
+        std::vector<bitLenInt> q(n);
+        for (uintq i = 0U; i < n; ++i) {
+            q[i] = shards[simulators[sid].get()][c[i]];
+        }
+        simulator->IQFTR(q);
 #endif
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
@@ -2160,7 +2161,7 @@ MICROSOFT_QUANTUM_DECL void MCADD(_In_ uintq sid, _In_ uintq na, _In_reads_(na) 
     try {
         bitCapInt aTot = _combineA(na, a);
         uintq start = MapArithmetic(simulator, nq, q);
-        simulator->CINC(aTot, start, nq, ctrlsArray.get(), nc);
+        simulator->CINC(aTot, start, nq, ctrlsArray);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -2174,7 +2175,7 @@ MICROSOFT_QUANTUM_DECL void MCSUB(_In_ uintq sid, _In_ uintq na, _In_reads_(na) 
     try {
         bitCapInt aTot = _combineA(na, a);
         uintq start = MapArithmetic(simulator, nq, q);
-        simulator->CDEC(aTot, start, nq, ctrlsArray.get(), nc);
+        simulator->CDEC(aTot, start, nq, ctrlsArray);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -2268,7 +2269,7 @@ MICROSOFT_QUANTUM_DECL void MCMUL(_In_ uintq sid, _In_ uintq na, _In_reads_(na) 
     try {
         bitCapInt aTot = _combineA(na, a);
         MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
-        QALU(simulator)->CMUL(aTot, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+        QALU(simulator)->CMUL(aTot, starts.start1, starts.start2, n, ctrlsArray);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -2282,7 +2283,7 @@ MICROSOFT_QUANTUM_DECL void MCDIV(_In_ uintq sid, _In_ uintq na, _In_reads_(na) 
     try {
         bitCapInt aTot = _combineA(na, a);
         MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
-        QALU(simulator)->CDIV(aTot, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+        QALU(simulator)->CDIV(aTot, starts.start1, starts.start2, n, ctrlsArray);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -2297,7 +2298,7 @@ MICROSOFT_QUANTUM_DECL void MCMULN(_In_ uintq sid, _In_ uintq na, _In_reads_(na)
         bitCapInt aTot = _combineA(na, a);
         bitCapInt mTot = _combineA(na, m);
         MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
-        QALU(simulator)->CMULModNOut(aTot, mTot, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+        QALU(simulator)->CMULModNOut(aTot, mTot, starts.start1, starts.start2, n, ctrlsArray);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -2312,7 +2313,7 @@ MICROSOFT_QUANTUM_DECL void MCDIVN(_In_ uintq sid, _In_ uintq na, _In_reads_(na)
         bitCapInt aTot = _combineA(na, a);
         bitCapInt mTot = _combineA(na, m);
         MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
-        QALU(simulator)->CIMULModNOut(aTot, mTot, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+        QALU(simulator)->CIMULModNOut(aTot, mTot, starts.start1, starts.start2, n, ctrlsArray);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -2327,7 +2328,7 @@ MICROSOFT_QUANTUM_DECL void MCPOWN(_In_ uintq sid, _In_ uintq na, _In_reads_(na)
         bitCapInt aTot = _combineA(na, a);
         bitCapInt mTot = _combineA(na, m);
         MapArithmeticResult2 starts = MapArithmetic2(simulator, n, q, o);
-        QALU(simulator)->CPOWModNOut(aTot, mTot, starts.start1, starts.start2, n, ctrlsArray.get(), nc);
+        QALU(simulator)->CPOWModNOut(aTot, mTot, starts.start1, starts.start2, n, ctrlsArray);
     } catch (const std::exception& ex) {
         simulatorErrors[sid] = 1;
         std::cout << ex.what() << std::endl;
@@ -2422,14 +2423,14 @@ MICROSOFT_QUANTUM_DECL bool TrySeparateTol(_In_ uintq sid, _In_ uintq n, _In_rea
     SIMULATOR_LOCK_GUARD_BOOL(sid)
 
     QInterfacePtr simulator = simulators[sid];
-    std::unique_ptr<bitLenInt[]> bitArray(new bitLenInt[n]);
+    std::vector<bitLenInt> bitArray(n);
     for (uintq i = 0U; i < n; ++i) {
         bitArray[i] = shards[simulator.get()][q[i]];
     }
 
     try {
         QInterfacePtr simulator = simulators[sid];
-        return simulator->TrySeparate(bitArray.get(), (bitLenInt)n, (real1_f)tol);
+        return simulator->TrySeparate(bitArray, (real1_f)tol);
     } catch (...) {
         simulatorErrors[sid] = 1;
         return false;

--- a/src/qalu.cpp
+++ b/src/qalu.cpp
@@ -26,10 +26,10 @@ void QAlu::DEC(bitCapInt toSub, bitLenInt start, bitLenInt length)
 }
 
 /// Subtract integer (without sign, with controls)
-void QAlu::CDEC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt const* controls, bitLenInt controlLen)
+void QAlu::CDEC(bitCapInt toSub, bitLenInt start, bitLenInt length, const std::vector<bitLenInt>& controls)
 {
-    const bitCapInt invToSub = pow2(length) - toSub;
-    CINC(invToSub, start, length, controls, controlLen);
+    const bitCapInt invToSub = pow2(controls.size()) - toSub;
+    CINC(invToSub, start, length, controls);
 }
 
 /**

--- a/src/qalu.cpp
+++ b/src/qalu.cpp
@@ -28,7 +28,7 @@ void QAlu::DEC(bitCapInt toSub, bitLenInt start, bitLenInt length)
 /// Subtract integer (without sign, with controls)
 void QAlu::CDEC(bitCapInt toSub, bitLenInt start, bitLenInt length, const std::vector<bitLenInt>& controls)
 {
-    const bitCapInt invToSub = pow2(controls.size()) - toSub;
+    const bitCapInt invToSub = pow2(length) - toSub;
     CINC(invToSub, start, length, controls);
 }
 

--- a/src/qbdt/node.cpp
+++ b/src/qbdt/node.cpp
@@ -356,7 +356,7 @@ void QBdtNode::PushStateVector(const complex2& mtrxCol1, const complex2& mtrxCol
     b1->PopStateVector();
 }
 #else
-void QBdtNode::Apply2x2(const complex* mtrx, bitLenInt depth)
+void QBdtNode::Apply2x2(complex const* mtrx, bitLenInt depth)
 {
     if (!depth) {
         return;
@@ -387,7 +387,7 @@ void QBdtNode::Apply2x2(const complex* mtrx, bitLenInt depth)
     Prune(depth);
 }
 
-void QBdtNode::PushStateVector(const complex* mtrx, QBdtNodeInterfacePtr& b0, QBdtNodeInterfacePtr& b1, bitLenInt depth)
+void QBdtNode::PushStateVector(complex const* mtrx, QBdtNodeInterfacePtr& b0, QBdtNodeInterfacePtr& b1, bitLenInt depth)
 {
     const bool isB0Zero = IS_NORM_0(b0->scale);
     const bool isB1Zero = IS_NORM_0(b1->scale);

--- a/src/qbdt/qengine_node.cpp
+++ b/src/qbdt/qengine_node.cpp
@@ -157,7 +157,7 @@ void QBdtQEngineNode::PushSpecial(const complex2& mtrxCol1, const complex2& mtrx
 {
     const complex mtrx[4U]{ mtrxCol1.c[0U], mtrxCol2.c[0U], mtrxCol1.c[1U], mtrxCol2.c[1U] };
 #else
-void QBdtQEngineNode::PushSpecial(const complex* mtrx, QBdtNodeInterfacePtr& b1)
+void QBdtQEngineNode::PushSpecial(complex const* mtrx, QBdtNodeInterfacePtr& b1)
 {
 #endif
     const bool is0Zero = IS_NORM_0(scale);

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -670,21 +670,21 @@ void QBdt::ApplySingle(const complex* mtrx, bitLenInt target)
 }
 
 void QBdt::ApplyControlledSingle(
-    const complex* mtrx, const bitLenInt* controls, bitLenInt controlLen, bitLenInt target, bool isAnti)
+    const complex* mtrx, const std::vector<bitLenInt>& controls, bitLenInt target, bool isAnti)
 {
     if (target >= qubitCount) {
         throw std::invalid_argument(
             "QBdt::ApplyControlledSingle target parameter must be within allocated qubit bounds!");
     }
 
-    ThrowIfQbIdArrayIsBad(controls, controlLen, qubitCount,
+    ThrowIfQbIdArrayIsBad(controls, qubitCount,
         "QBdt::ApplyControlledSingle parameter controls array values must be within allocated qubit bounds!");
 
     if (!bdtQubitCount) {
         if (isAnti) {
-            NODE_TO_QENGINE(root)->MACMtrx(controls, controlLen, mtrx, target);
+            NODE_TO_QENGINE(root)->MACMtrx(controls, mtrx, target);
         } else {
-            NODE_TO_QENGINE(root)->MCMtrx(controls, controlLen, mtrx, target);
+            NODE_TO_QENGINE(root)->MCMtrx(controls, mtrx, target);
         }
         return;
     }
@@ -694,8 +694,7 @@ void QBdt::ApplyControlledSingle(
         return;
     }
 
-    std::vector<bitLenInt> controlVec(controlLen);
-    std::copy(controls, controls + controlLen, controlVec.begin());
+    std::vector<bitLenInt> controlVec(controls.begin(), controls.end());
     std::sort(controlVec.begin(), controlVec.end());
     const bool isSwapped = (target < controlVec.back()) && (target < bdtQubitCount);
     if (isSwapped) {
@@ -708,7 +707,7 @@ void QBdt::ApplyControlledSingle(
     const bitCapInt qPower = pow2(maxQubit);
     std::vector<bitLenInt> ketControlsVec;
     bitCapInt lowControlMask = 0U;
-    for (bitLenInt c = 0U; c < controlLen; ++c) {
+    for (bitLenInt c = 0U; c < controls.size(); ++c) {
         const bitLenInt control = controlVec[c];
         if (control < bdtQubitCount) {
             lowControlMask |= pow2(maxQubit - (control + 1U));
@@ -717,8 +716,6 @@ void QBdt::ApplyControlledSingle(
         }
     }
     bitCapInt lowControlPerm = isAnti ? 0U : lowControlMask;
-    std::unique_ptr<bitLenInt[]> ketControls = std::unique_ptr<bitLenInt[]>(new bitLenInt[ketControlsVec.size()]);
-    std::copy(ketControlsVec.begin(), ketControlsVec.end(), ketControls.get());
 
 #if ENABLE_COMPLEX_X2
     const complex2 mtrxCol1(mtrx[0U], mtrx[2U]);
@@ -749,9 +746,9 @@ void QBdt::ApplyControlledSingle(
             leaf->Branch();
             QEnginePtr qi = NODE_TO_QENGINE(leaf);
             if (isAnti) {
-                qi->MACMtrx(ketControls.get(), ketControlsVec.size(), mtrx, target - bdtQubitCount);
+                qi->MACMtrx(ketControlsVec, mtrx, target - bdtQubitCount);
             } else {
-                qi->MCMtrx(ketControls.get(), ketControlsVec.size(), mtrx, target - bdtQubitCount);
+                qi->MCMtrx(ketControlsVec, mtrx, target - bdtQubitCount);
             }
         } else {
 #if ENABLE_COMPLEX_X2
@@ -774,44 +771,43 @@ void QBdt::ApplyControlledSingle(
 
 void QBdt::Mtrx(const complex* mtrx, bitLenInt target) { ApplySingle(mtrx, target); }
 
-void QBdt::MCMtrx(const bitLenInt* controls, bitLenInt controlLen, const complex* mtrx, bitLenInt target)
+void QBdt::MCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         Mtrx(mtrx, target);
     } else if (IS_NORM_0(mtrx[1U]) && IS_NORM_0(mtrx[2U])) {
-        MCPhase(controls, controlLen, mtrx[0U], mtrx[3U], target);
+        MCPhase(controls, mtrx[0U], mtrx[3U], target);
     } else if (IS_NORM_0(mtrx[0U]) && IS_NORM_0(mtrx[3U])) {
-        MCInvert(controls, controlLen, mtrx[1U], mtrx[2U], target);
+        MCInvert(controls, mtrx[1U], mtrx[2U], target);
     } else {
-        ApplyControlledSingle(mtrx, controls, controlLen, target, false);
+        ApplyControlledSingle(mtrx, controls, target, false);
     }
 }
 
-void QBdt::MACMtrx(const bitLenInt* controls, bitLenInt controlLen, const complex* mtrx, bitLenInt target)
+void QBdt::MACMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
 {
 
-    if (!controlLen) {
+    if (!controls.size()) {
         Mtrx(mtrx, target);
     } else if (IS_NORM_0(mtrx[1U]) && IS_NORM_0(mtrx[2U])) {
-        MACPhase(controls, controlLen, mtrx[0U], mtrx[3U], target);
+        MACPhase(controls, mtrx[0U], mtrx[3U], target);
     } else if (IS_NORM_0(mtrx[0U]) && IS_NORM_0(mtrx[3U])) {
-        MACInvert(controls, controlLen, mtrx[1U], mtrx[2U], target);
+        MACInvert(controls, mtrx[1U], mtrx[2U], target);
     } else {
-        ApplyControlledSingle(mtrx, controls, controlLen, target, true);
+        ApplyControlledSingle(mtrx, controls, target, true);
     }
 }
 
-void QBdt::MCPhase(
-    const bitLenInt* controls, bitLenInt controlLen, complex topLeft, complex bottomRight, bitLenInt target)
+void QBdt::MCPhase(const std::vector<bitLenInt>& controls, complex topLeft, complex bottomRight, bitLenInt target)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         Phase(topLeft, bottomRight, target);
         return;
     }
 
     const complex mtrx[4U]{ topLeft, ZERO_CMPLX, ZERO_CMPLX, bottomRight };
     if (!IS_NORM_0(ONE_CMPLX - topLeft)) {
-        ApplyControlledSingle(mtrx, controls, controlLen, target, false);
+        ApplyControlledSingle(mtrx, controls, target, false);
         return;
     }
 
@@ -819,28 +815,26 @@ void QBdt::MCPhase(
         return;
     }
 
-    std::unique_ptr<bitLenInt[]> lControls = std::unique_ptr<bitLenInt[]>(new bitLenInt[controlLen]);
-    std::copy(controls, controls + controlLen, lControls.get());
-    std::sort(lControls.get(), lControls.get() + controlLen);
+    std::vector<bitLenInt> lControls(controls);
+    std::sort(lControls.begin(), lControls.end());
 
-    if (target < lControls[controlLen - 1U]) {
-        std::swap(target, lControls[controlLen - 1U]);
+    if (target < lControls[controls.size() - 1U]) {
+        std::swap(target, lControls[controls.size() - 1U]);
     }
 
-    ApplyControlledSingle(mtrx, lControls.get(), controlLen, target, false);
+    ApplyControlledSingle(mtrx, lControls, target, false);
 }
 
-void QBdt::MACPhase(
-    const bitLenInt* controls, bitLenInt controlLen, complex topLeft, complex bottomRight, bitLenInt target)
+void QBdt::MACPhase(const std::vector<bitLenInt>& controls, complex topLeft, complex bottomRight, bitLenInt target)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         Phase(topLeft, bottomRight, target);
         return;
     }
 
     const complex mtrx[4U]{ topLeft, ZERO_CMPLX, ZERO_CMPLX, bottomRight };
     if (!IS_NORM_0(ONE_CMPLX - bottomRight)) {
-        ApplyControlledSingle(mtrx, controls, controlLen, target, true);
+        ApplyControlledSingle(mtrx, controls, target, true);
         return;
     }
 
@@ -848,70 +842,65 @@ void QBdt::MACPhase(
         return;
     }
 
-    std::unique_ptr<bitLenInt[]> lControls = std::unique_ptr<bitLenInt[]>(new bitLenInt[controlLen]);
-    std::copy(controls, controls + controlLen, lControls.get());
-    std::sort(lControls.get(), lControls.get() + controlLen);
+    std::vector<bitLenInt> lControls(controls);
+    std::sort(lControls.begin(), lControls.end());
 
-    if (target < lControls[controlLen - 1U]) {
-        std::swap(target, lControls[controlLen - 1U]);
+    if (target < lControls[controls.size() - 1U]) {
+        std::swap(target, lControls[controls.size() - 1U]);
     }
 
-    ApplyControlledSingle(mtrx, lControls.get(), controlLen, target, true);
+    ApplyControlledSingle(mtrx, lControls, target, true);
 }
 
-void QBdt::MCInvert(
-    const bitLenInt* controls, bitLenInt controlLen, complex topRight, complex bottomLeft, bitLenInt target)
+void QBdt::MCInvert(const std::vector<bitLenInt>& controls, complex topRight, complex bottomLeft, bitLenInt target)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         Invert(topRight, bottomLeft, target);
         return;
     }
 
     const complex mtrx[4U]{ ZERO_CMPLX, topRight, bottomLeft, ZERO_CMPLX };
     if (!IS_NORM_0(ONE_CMPLX - topRight) || !IS_NORM_0(ONE_CMPLX - bottomLeft)) {
-        ApplyControlledSingle(mtrx, controls, controlLen, target, false);
+        ApplyControlledSingle(mtrx, controls, target, false);
         return;
     }
 
-    std::unique_ptr<bitLenInt[]> lControls = std::unique_ptr<bitLenInt[]>(new bitLenInt[controlLen]);
-    std::copy(controls, controls + controlLen, lControls.get());
-    std::sort(lControls.get(), lControls.get() + controlLen);
+    std::vector<bitLenInt> lControls(controls);
+    std::sort(lControls.begin(), lControls.end());
 
-    if ((lControls[controlLen - 1U] < target) || (target >= bdtQubitCount)) {
-        ApplyControlledSingle(mtrx, lControls.get(), controlLen, target, false);
+    if ((lControls[controls.size() - 1U] < target) || (target >= bdtQubitCount)) {
+        ApplyControlledSingle(mtrx, lControls, target, false);
         return;
     }
 
     H(target);
-    MCPhase(lControls.get(), controlLen, ONE_CMPLX, -ONE_CMPLX, target);
+    MCPhase(lControls, ONE_CMPLX, -ONE_CMPLX, target);
     H(target);
 }
 
-void QBdt::MACInvert(
-    const bitLenInt* controls, bitLenInt controlLen, complex topRight, complex bottomLeft, bitLenInt target)
+void QBdt::MACInvert(const std::vector<bitLenInt>& controls, complex topRight, complex bottomLeft, bitLenInt target)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         Invert(topRight, bottomLeft, target);
         return;
     }
 
     const complex mtrx[4U]{ ZERO_CMPLX, topRight, bottomLeft, ZERO_CMPLX };
     if (!IS_NORM_0(ONE_CMPLX + topRight) || !IS_NORM_0(ONE_CMPLX + bottomLeft)) {
-        ApplyControlledSingle(mtrx, controls, controlLen, target, true);
+        ApplyControlledSingle(mtrx, controls, target, true);
         return;
     }
 
-    std::unique_ptr<bitLenInt[]> lControls = std::unique_ptr<bitLenInt[]>(new bitLenInt[controlLen]);
-    std::copy(controls, controls + controlLen, lControls.get());
-    std::sort(lControls.get(), lControls.get() + controlLen);
+    std::vector<bitLenInt> lControls(controls);
+    std::sort(lControls.begin(), lControls.end());
 
-    if ((lControls[controlLen - 1U] < target) || (target >= bdtQubitCount)) {
-        ApplyControlledSingle(mtrx, lControls.get(), controlLen, target, true);
+    if ((lControls[controls.size() - 1U] < target) || (target >= bdtQubitCount)) {
+        ApplyControlledSingle(mtrx, lControls, target, true);
         return;
     }
 
     H(target);
-    MACPhase(lControls.get(), controlLen, -ONE_CMPLX, ONE_CMPLX, target);
+    MACPhase(lControls, -ONE_CMPLX, ONE_CMPLX, target);
     H(target);
 }
 } // namespace Qrack

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -227,7 +227,7 @@ void QBdt::GetQuantumState(QInterfacePtr eng)
 {
     GetTraversal([eng](bitCapIntOcl i, complex scale) { eng->SetAmplitude(i, scale); });
 }
-void QBdt::SetQuantumState(const complex* state)
+void QBdt::SetQuantumState(complex const* state)
 {
     if (!bdtQubitCount) {
         NODE_TO_QENGINE(root)->SetQuantumState(state);
@@ -611,7 +611,7 @@ bitCapInt QBdt::MAll()
     return result;
 }
 
-void QBdt::ApplySingle(const complex* mtrx, bitLenInt target)
+void QBdt::ApplySingle(complex const* mtrx, bitLenInt target)
 {
     if (target >= qubitCount) {
         throw std::invalid_argument("QBdt::ApplySingle target parameter must be within allocated qubit bounds!");
@@ -670,7 +670,7 @@ void QBdt::ApplySingle(const complex* mtrx, bitLenInt target)
 }
 
 void QBdt::ApplyControlledSingle(
-    const complex* mtrx, const std::vector<bitLenInt>& controls, bitLenInt target, bool isAnti)
+    complex const* mtrx, const std::vector<bitLenInt>& controls, bitLenInt target, bool isAnti)
 {
     if (target >= qubitCount) {
         throw std::invalid_argument(
@@ -769,9 +769,9 @@ void QBdt::ApplyControlledSingle(
     }
 }
 
-void QBdt::Mtrx(const complex* mtrx, bitLenInt target) { ApplySingle(mtrx, target); }
+void QBdt::Mtrx(complex const* mtrx, bitLenInt target) { ApplySingle(mtrx, target); }
 
-void QBdt::MCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
+void QBdt::MCMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target)
 {
     if (!controls.size()) {
         Mtrx(mtrx, target);
@@ -784,7 +784,7 @@ void QBdt::MCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, b
     }
 }
 
-void QBdt::MACMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
+void QBdt::MACMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target)
 {
 
     if (!controls.size()) {

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -156,7 +156,7 @@ void QEngineOCL::GetAmplitudePage(complex* pagePtr, bitCapIntOcl offset, bitCapI
     DISPATCH_BLOCK_READ(waitVec, *stateBuffer, sizeof(complex) * offset, sizeof(complex) * length, pagePtr);
 }
 
-void QEngineOCL::SetAmplitudePage(const complex* pagePtr, bitCapIntOcl offset, bitCapIntOcl length)
+void QEngineOCL::SetAmplitudePage(complex const* pagePtr, bitCapIntOcl offset, bitCapIntOcl length)
 {
     if (isBadPermRange(offset, length, maxQPowerOcl)) {
         throw std::invalid_argument("QEngineOCL::SetAmplitudePage range is out-of-bounds!");
@@ -743,7 +743,7 @@ void QEngineOCL::Phase(complex topLeft, complex bottomRight, bitLenInt qubitInde
     Apply2x2(0U, qPowers[0], pauliZ, 1U, qPowers, false, SPECIAL_2X2::PHASE);
 }
 
-void QEngineOCL::Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const complex* mtrx, bitLenInt bitCount,
+void QEngineOCL::Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, complex const* mtrx, bitLenInt bitCount,
     const bitCapIntOcl* qPowersSorted, bool doCalcNorm, SPECIAL_2X2 special, real1_f norm_thresh)
 {
     CHECK_ZERO_SKIP();
@@ -1015,7 +1015,7 @@ void QEngineOCL::BitMask(bitCapIntOcl mask, OCLAPI api_call, real1_f phase)
 }
 
 void QEngineOCL::UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls, bitLenInt qubitIndex,
-    const complex* mtrxs, const std::vector<bitCapInt>& mtrxSkipPowers, bitCapInt mtrxSkipValueMask)
+    complex const* mtrxs, const std::vector<bitCapInt>& mtrxSkipPowers, bitCapInt mtrxSkipValueMask)
 {
     CHECK_ZERO_SKIP();
 
@@ -2911,7 +2911,7 @@ void QEngineOCL::PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenI
 #endif
 
 /// Set arbitrary pure quantum state, in unsigned int permutation basis
-void QEngineOCL::SetQuantumState(const complex* inputState)
+void QEngineOCL::SetQuantumState(complex const* inputState)
 {
     clDump();
 

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -1014,13 +1014,13 @@ void QEngineOCL::BitMask(bitCapIntOcl mask, OCLAPI api_call, real1_f phase)
     }
 }
 
-void QEngineOCL::UniformlyControlledSingleBit(const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubitIndex,
-    const complex* mtrxs, const bitCapInt* mtrxSkipPowers, bitLenInt mtrxSkipLen, bitCapInt mtrxSkipValueMask)
+void QEngineOCL::UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls, bitLenInt qubitIndex,
+    const complex* mtrxs, const std::vecto<bitCapInt>& mtrxSkipPowers, bitCapInt mtrxSkipValueMask)
 {
     CHECK_ZERO_SKIP();
 
     // If there are no controls, the base case should be the non-controlled single bit gate.
-    if (!controlLen) {
+    if (!controls.size()) {
         Mtrx(mtrxs + (bitCapIntOcl)(mtrxSkipValueMask * 4U), qubitIndex);
         return;
     }
@@ -1029,8 +1029,7 @@ void QEngineOCL::UniformlyControlledSingleBit(const bitLenInt* controls, bitLenI
         throw std::invalid_argument("QEngineOCL::UniformlyControlledSingleBit qubitIndex is out-of-bounds!");
     }
 
-    ThrowIfQbIdArrayIsBad(
-        controls, controlLen, qubitCount, "QEngineOCL::UniformlyControlledSingleBit control is out-of-bounds!");
+    ThrowIfQbIdArrayIsBad(controls, qubitCount, "QEngineOCL::UniformlyControlledSingleBit control is out-of-bounds!");
 
     // We grab the wait event queue. We will replace it with three new asynchronous events, to wait for.
     EventVecPtr waitVec = ResetWaitEvents();
@@ -1040,7 +1039,7 @@ void QEngineOCL::UniformlyControlledSingleBit(const bitLenInt* controls, bitLenI
 
     // Load the integer kernel arguments buffer.
     const bitCapIntOcl maxI = maxQPowerOcl >> ONE_BCI;
-    const bitCapIntOcl bciArgs[BCI_ARG_LEN]{ maxI, pow2Ocl(qubitIndex), controlLen, mtrxSkipLen,
+    const bitCapIntOcl bciArgs[BCI_ARG_LEN]{ maxI, pow2Ocl(qubitIndex), controls.size(), mtrxSkipPowers.size(),
         (bitCapIntOcl)mtrxSkipValueMask, 0U, 0U, 0U, 0U, 0U };
     DISPATCH_WRITE(waitVec, *(poolItem->ulongBuffer), sizeof(bitCapIntOcl) * 5, bciArgs);
 
@@ -1048,18 +1047,19 @@ void QEngineOCL::UniformlyControlledSingleBit(const bitLenInt* controls, bitLenI
     const real1 nrm = (runningNorm > ZERO_R1) ? ONE_R1 / (real1)sqrt(runningNorm) : ONE_R1;
     DISPATCH_WRITE(waitVec, *nrmInBuffer, sizeof(real1), &nrm);
 
-    const size_t sizeDiff = sizeof(complex) * 4U * pow2Ocl(controlLen + mtrxSkipLen);
+    const size_t sizeDiff = sizeof(complex) * 4U * pow2Ocl(controls.size() + mtrxSkipPowers.size());
     AddAlloc(sizeDiff);
     BufferPtr uniformBuffer = MakeBuffer(CL_MEM_READ_ONLY, sizeDiff);
 
-    DISPATCH_WRITE(waitVec, *uniformBuffer, sizeof(complex) * 4U * pow2Ocl(controlLen + mtrxSkipLen), mtrxs);
+    DISPATCH_WRITE(
+        waitVec, *uniformBuffer, sizeof(complex) * 4U * pow2Ocl(controls.size() + mtrxSkipPowers.size()), mtrxs);
 
-    std::unique_ptr<bitCapIntOcl[]> qPowers(new bitCapIntOcl[controlLen + mtrxSkipLen]);
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    std::unique_ptr<bitCapIntOcl[]> qPowers(new bitCapIntOcl[controls.size() + mtrxSkipPowers.size()]);
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         qPowers[i] = pow2Ocl(controls[i]);
     }
-    for (bitLenInt i = 0U; i < mtrxSkipLen; ++i) {
-        qPowers[controlLen + i] = (bitCapIntOcl)mtrxSkipPowers[i];
+    for (bitLenInt i = 0U; i < mtrxSkipPowers.size(); ++i) {
+        qPowers[controls.size() + i] = (bitCapIntOcl)mtrxSkipPowers[i];
     }
 
     // We have default OpenCL work item counts and group sizes, but we may need to use different values due to the total
@@ -1068,7 +1068,8 @@ void QEngineOCL::UniformlyControlledSingleBit(const bitLenInt* controls, bitLenI
     const size_t ngs = FixGroupSize(ngc, nrmGroupSize);
 
     // Load a buffer with the powers of 2 of each bit index involved in the operation.
-    DISPATCH_WRITE(waitVec, *powersBuffer, sizeof(bitCapIntOcl) * (controlLen + mtrxSkipLen), qPowers.get());
+    DISPATCH_WRITE(
+        waitVec, *powersBuffer, sizeof(bitCapIntOcl) * (controls.size() + mtrxSkipPowers.size()), qPowers.get());
 
     // We call the kernel, with global buffers and one local buffer.
     WaitCall(OCL_API_UNIFORMLYCONTROLLED, ngc, ngs,
@@ -1119,9 +1120,9 @@ void QEngineOCL::UniformParityRZ(bitCapInt mask, real1_f angle)
     QueueSetRunningNorm(ONE_R1_F);
 }
 
-void QEngineOCL::CUniformParityRZ(const bitLenInt* controls, bitLenInt controlLen, bitCapInt mask, real1_f angle)
+void QEngineOCL::CUniformParityRZ(const std::vector<bitLenInt>& controls, bitCapInt mask, real1_f angle)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         UniformParityRZ(mask, angle);
         return;
     }
@@ -1130,23 +1131,23 @@ void QEngineOCL::CUniformParityRZ(const bitLenInt* controls, bitLenInt controlLe
         throw std::invalid_argument("QEngineOCL::CUniformParityRZ mask out-of-bounds!");
     }
 
-    ThrowIfQbIdArrayIsBad(controls, controlLen, qubitCount, "QEngineOCL::CUniformParityRZ control is out-of-bounds!");
+    ThrowIfQbIdArrayIsBad(controls, qubitCount, "QEngineOCL::CUniformParityRZ control is out-of-bounds!");
 
     CHECK_ZERO_SKIP();
 
     bitCapIntOcl controlMask = 0U;
-    std::unique_ptr<bitCapIntOcl[]> controlPowers(new bitCapIntOcl[controlLen]);
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    std::unique_ptr<bitCapIntOcl[]> controlPowers(new bitCapIntOcl[controls.size()]);
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         controlPowers[i] = pow2Ocl(controls[i]);
         controlMask |= controlPowers[i];
     }
-    std::sort(controlPowers.get(), controlPowers.get() + controlLen);
-    BufferPtr controlBuffer =
-        MakeBuffer(CL_MEM_COPY_HOST_PTR | CL_MEM_READ_ONLY, sizeof(bitCapIntOcl) * controlLen, controlPowers.get());
+    std::sort(controlPowers.get(), controlPowers.get() + controls.size());
+    BufferPtr controlBuffer = MakeBuffer(
+        CL_MEM_COPY_HOST_PTR | CL_MEM_READ_ONLY, sizeof(bitCapIntOcl) * controls.size(), controlPowers.get());
     controlPowers.reset();
 
-    const bitCapIntOcl bciArgs[BCI_ARG_LEN]{ (bitCapIntOcl)(maxQPowerOcl >> controlLen), (bitCapIntOcl)mask,
-        controlMask, controlLen, 0U, 0U, 0U, 0U, 0U, 0U };
+    const bitCapIntOcl bciArgs[BCI_ARG_LEN]{ (bitCapIntOcl)(maxQPowerOcl >> controls.size()), (bitCapIntOcl)mask,
+        controlMask, controls.size(), 0U, 0U, 0U, 0U, 0U, 0U };
     const real1 cosine = (real1)cos(angle);
     const real1 sine = (real1)sin(angle);
     const complex phaseFacs[2]{ complex(cosine, sine), complex(cosine, -sine) };
@@ -1938,7 +1939,7 @@ bool QEngineOCL::ForceMParity(bitCapInt mask, bool result, bool doForce)
     return result;
 }
 
-real1_f QEngineOCL::ExpectationBitsAll(const bitLenInt* bits, bitLenInt length, bitCapInt offset)
+real1_f QEngineOCL::ExpectationBitsAll(const std::vector<bitLenInt>& bits, bitCapInt offset)
 {
     if (length == 1U) {
         return Prob(bits[0]);
@@ -2126,14 +2127,14 @@ void QEngineOCL::INT(OCLAPI api_call, bitCapIntOcl toMod, bitLenInt start, bitLe
 }
 
 /// Add or Subtract integer (without sign or carry, with controls)
-void QEngineOCL::CINT(OCLAPI api_call, bitCapIntOcl toMod, bitLenInt start, bitLenInt length, const bitLenInt* controls,
-    bitLenInt controlLen)
+void QEngineOCL::CINT(
+    OCLAPI api_call, bitCapIntOcl toMod, bitLenInt start, bitLenInt length, const std::vector<bitLenInt>& controls)
 {
     if (isBadBitRange(start, length, qubitCount)) {
         throw std::invalid_argument("QEngineOCL::CINT range is out-of-bounds!");
     }
 
-    ThrowIfQbIdArrayIsBad(controls, controlLen, qubitCount, "QEngineOCL::CINT control is out-of-bounds!");
+    ThrowIfQbIdArrayIsBad(controls, qubitCount, "QEngineOCL::CINT control is out-of-bounds!");
 
     if (!length) {
         return;
@@ -2149,18 +2150,18 @@ void QEngineOCL::CINT(OCLAPI api_call, bitCapIntOcl toMod, bitLenInt start, bitL
     const bitCapIntOcl regMask = lengthMask << start;
 
     bitCapIntOcl controlMask = 0U;
-    std::unique_ptr<bitCapIntOcl[]> controlPowers(new bitCapIntOcl[controlLen]);
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    std::vector<bitCapIntOcl> controlPowers(controls.size());
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         controlPowers[i] = pow2Ocl(controls[i]);
         controlMask |= controlPowers[i];
     }
-    std::sort(controlPowers.get(), controlPowers.get() + controlLen);
+    std::sort(controlPowers.get(), controlPowers.get() + controls.size());
 
     const bitCapIntOcl otherMask = (maxQPowerOcl - ONE_BCI) ^ (regMask | controlMask);
-    const bitCapIntOcl bciArgs[BCI_ARG_LEN]{ (bitCapIntOcl)(maxQPowerOcl >> controlLen), regMask, otherMask,
-        lengthPower, start, toMod, controlLen, controlMask, 0U, 0U };
+    const bitCapIntOcl bciArgs[BCI_ARG_LEN]{ (bitCapIntOcl)(maxQPowerOcl >> controls.size()), regMask, otherMask,
+        lengthPower, start, toMod, controls.size(), controlMask, 0U, 0U };
 
-    CArithmeticCall(api_call, bciArgs, controlPowers.get(), controlLen);
+    CArithmeticCall(api_call, bciArgs, controlPowers);
 }
 
 /** Increment integer (without sign, with carry) */
@@ -2169,15 +2170,14 @@ void QEngineOCL::INC(bitCapInt toAdd, bitLenInt start, bitLenInt length)
     INT(OCL_API_INC, (bitCapIntOcl)toAdd, start, length);
 }
 
-void QEngineOCL::CINC(
-    bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const bitLenInt* controls, bitLenInt controlLen)
+void QEngineOCL::CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const std::vector<bitLenInt>& controls)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         INC(toAdd, inOutStart, length);
         return;
     }
 
-    CINT(OCL_API_CINC, (bitCapIntOcl)toAdd, inOutStart, length, controls, controlLen);
+    CINT(OCL_API_CINC, (bitCapIntOcl)toAdd, inOutStart, length, controls);
 }
 
 /// Add or Subtract integer (without sign, with carry)
@@ -2499,11 +2499,11 @@ void QEngineOCL::FullAdx(
 
 /** Controlled multiplication by integer */
 void QEngineOCL::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
-    const bitLenInt* controls, bitLenInt controlLen)
+    const std::vector<bitLenInt>& controls)
 {
     CHECK_ZERO_SKIP();
 
-    if (!controlLen) {
+    if (!controls.size()) {
         MUL(toMul, inOutStart, carryStart, length);
         return;
     }
@@ -2516,14 +2516,14 @@ void QEngineOCL::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStar
         return;
     }
 
-    CMULx(OCL_API_CMUL, (bitCapIntOcl)toMul, inOutStart, carryStart, length, controls, controlLen);
+    CMULx(OCL_API_CMUL, (bitCapIntOcl)toMul, inOutStart, carryStart, length, controls);
 }
 
 /** Controlled division by integer */
 void QEngineOCL::CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
-    const bitLenInt* controls, bitLenInt controlLen)
+    const std::vector<bitLenInt>& controls)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         DIV(toDiv, inOutStart, carryStart, length);
         return;
     }
@@ -2536,16 +2536,16 @@ void QEngineOCL::CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStar
         return;
     }
 
-    CMULx(OCL_API_CDIV, (bitCapIntOcl)toDiv, inOutStart, carryStart, length, controls, controlLen);
+    CMULx(OCL_API_CDIV, (bitCapIntOcl)toDiv, inOutStart, carryStart, length, controls);
 }
 
 /** Controlled multiplication modulo N by integer, (out of place) */
 void QEngineOCL::CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-    const bitLenInt* controls, bitLenInt controlLen)
+    const std::vector<bitLenInt>& controls)
 {
     CHECK_ZERO_SKIP();
 
-    if (!controlLen) {
+    if (!controls.size()) {
         MULModNOut(toMul, modN, inStart, outStart, length);
         return;
     }
@@ -2558,14 +2558,13 @@ void QEngineOCL::CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart,
         return;
     }
 
-    CMULModx(
-        OCL_API_CMULMODN_OUT, (bitCapIntOcl)toMul, (bitCapIntOcl)modN, inStart, outStart, length, controls, controlLen);
+    CMULModx(OCL_API_CMULMODN_OUT, (bitCapIntOcl)toMul, (bitCapIntOcl)modN, inStart, outStart, length, controls);
 }
 
 void QEngineOCL::CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-    const bitLenInt* controls, bitLenInt controlLen)
+    const std::vector<bitLenInt>& controls)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         IMULModNOut(toMul, modN, inStart, outStart, length);
         return;
     }
@@ -2576,25 +2575,23 @@ void QEngineOCL::CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart
         return;
     }
 
-    CMULModx(OCL_API_CIMULMODN_OUT, (bitCapIntOcl)toMul, (bitCapIntOcl)modN, inStart, outStart, length, controls,
-        controlLen);
+    CMULModx(OCL_API_CIMULMODN_OUT, (bitCapIntOcl)toMul, (bitCapIntOcl)modN, inStart, outStart, length, controls);
 }
 
 /** Controlled multiplication modulo N by integer, (out of place) */
 void QEngineOCL::CPOWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-    const bitLenInt* controls, bitLenInt controlLen)
+    const std::vector<bitLenInt>& controls)
 {
     CHECK_ZERO_SKIP();
 
-    if (!controlLen) {
+    if (!controls.size()) {
         POWModNOut(base, modN, inStart, outStart, length);
         return;
     }
 
     SetReg(outStart, length, 0U);
 
-    CMULModx(
-        OCL_API_CPOWMODN_OUT, (bitCapIntOcl)base, (bitCapIntOcl)modN, inStart, outStart, length, controls, controlLen);
+    CMULModx(OCL_API_CPOWMODN_OUT, (bitCapIntOcl)base, (bitCapIntOcl)modN, inStart, outStart, length, controls);
 }
 
 void QEngineOCL::xMULx(OCLAPI api_call, const bitCapIntOcl* bciArgs, BufferPtr controlBuffer)
@@ -2674,7 +2671,7 @@ void QEngineOCL::MULModx(
 }
 
 void QEngineOCL::CMULx(OCLAPI api_call, bitCapIntOcl toMod, bitLenInt inOutStart, bitLenInt carryStart,
-    bitLenInt length, const bitLenInt* controls, bitLenInt controlLen)
+    bitLenInt length, const std::vector<bitLenInt>& controls)
 {
     if (isBadBitRange(inOutStart, length, qubitCount)) {
         throw std::invalid_argument("QEngineOCL::CMULx range is out-of-bounds!");
@@ -2684,29 +2681,29 @@ void QEngineOCL::CMULx(OCLAPI api_call, bitCapIntOcl toMod, bitLenInt inOutStart
         throw std::invalid_argument("QEngineOCL::CMULx range is out-of-bounds!");
     }
 
-    ThrowIfQbIdArrayIsBad(controls, controlLen, qubitCount, "QEngineOCL::CMULx control is out-of-bounds!");
+    ThrowIfQbIdArrayIsBad(controls, qubitCount, "QEngineOCL::CMULx control is out-of-bounds!");
 
     const bitCapIntOcl lowMask = pow2MaskOcl(length);
     const bitCapIntOcl inOutMask = lowMask << inOutStart;
     const bitCapIntOcl carryMask = lowMask << carryStart;
 
-    std::unique_ptr<bitCapIntOcl[]> skipPowers(new bitCapIntOcl[controlLen + length]);
+    std::unique_ptr<bitCapIntOcl[]> skipPowers(new bitCapIntOcl[controls.size() + length]);
     bitCapIntOcl controlMask = 0U;
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         bitCapIntOcl controlPower = pow2Ocl(controls[i]);
         skipPowers[i] = controlPower;
         controlMask |= controlPower;
     }
     for (bitLenInt i = 0U; i < length; ++i) {
-        skipPowers[i + controlLen] = pow2Ocl(carryStart + i);
+        skipPowers[i + controls.size()] = pow2Ocl(carryStart + i);
     }
-    std::sort(skipPowers.get(), skipPowers.get() + controlLen + length);
+    std::sort(skipPowers.get(), skipPowers.get() + controls.size() + length);
 
     const bitCapIntOcl otherMask = (maxQPowerOcl - ONE_BCI) ^ (inOutMask | carryMask | controlMask);
-    const bitCapIntOcl bciArgs[BCI_ARG_LEN]{ (bitCapIntOcl)(maxQPowerOcl >> (bitCapIntOcl)(controlLen + length)), toMod,
-        controlLen, controlMask, inOutMask, carryMask, otherMask, length, inOutStart, carryStart };
+    const bitCapIntOcl bciArgs[BCI_ARG_LEN]{ (bitCapIntOcl)(maxQPowerOcl >> (bitCapIntOcl)(controls.size() + length)),
+        toMod, controls.size(), controlMask, inOutMask, carryMask, otherMask, length, inOutStart, carryStart };
 
-    const size_t sizeDiff = sizeof(bitCapIntOcl) * ((controlLen * 2U) + length);
+    const size_t sizeDiff = sizeof(bitCapIntOcl) * ((controls.size() * 2U) + length);
     AddAlloc(sizeDiff);
     BufferPtr controlBuffer = MakeBuffer(CL_MEM_COPY_HOST_PTR | CL_MEM_READ_ONLY, sizeDiff, skipPowers.get());
     skipPowers.reset();
@@ -2717,7 +2714,7 @@ void QEngineOCL::CMULx(OCLAPI api_call, bitCapIntOcl toMod, bitLenInt inOutStart
 }
 
 void QEngineOCL::CMULModx(OCLAPI api_call, bitCapIntOcl toMod, bitCapIntOcl modN, bitLenInt inOutStart,
-    bitLenInt carryStart, bitLenInt length, const bitLenInt* controls, bitLenInt controlLen)
+    bitLenInt carryStart, bitLenInt length, const std::vector<bitLenInt>& controls)
 {
     if (isBadBitRange(inOutStart, length, qubitCount)) {
         throw std::invalid_argument("QEngineOCL::CMULModx range is out-of-bounds!");
@@ -2727,28 +2724,28 @@ void QEngineOCL::CMULModx(OCLAPI api_call, bitCapIntOcl toMod, bitCapIntOcl modN
         throw std::invalid_argument("QEngineOCL::CMULModx range is out-of-bounds!");
     }
 
-    ThrowIfQbIdArrayIsBad(controls, controlLen, qubitCount, "QEngineOCL::CMULModx control is out-of-bounds!");
+    ThrowIfQbIdArrayIsBad(controls, qubitCount, "QEngineOCL::CMULModx control is out-of-bounds!");
 
     const bitCapIntOcl lowMask = pow2MaskOcl(length);
     const bitCapIntOcl inOutMask = lowMask << inOutStart;
     const bitCapIntOcl carryMask = lowMask << carryStart;
 
-    std::unique_ptr<bitCapIntOcl[]> skipPowers(new bitCapIntOcl[controlLen + length]);
+    std::unique_ptr<bitCapIntOcl[]> skipPowers(new bitCapIntOcl[controls.size() + length]);
     bitCapIntOcl controlMask = 0U;
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         bitCapIntOcl controlPower = pow2Ocl(controls[i]);
         skipPowers[i] = controlPower;
         controlMask |= controlPower;
     }
     for (bitLenInt i = 0U; i < length; ++i) {
-        skipPowers[i + controlLen] = pow2Ocl(carryStart + i);
+        skipPowers[i + controls.size()] = pow2Ocl(carryStart + i);
     }
-    std::sort(skipPowers.get(), skipPowers.get() + controlLen + length);
+    std::sort(skipPowers.get(), skipPowers.get() + controls.size() + length);
 
-    const bitCapIntOcl bciArgs[BCI_ARG_LEN]{ maxQPowerOcl, toMod, controlLen, controlMask, inOutMask, carryMask, modN,
-        length, inOutStart, carryStart };
+    const bitCapIntOcl bciArgs[BCI_ARG_LEN]{ maxQPowerOcl, toMod, controls.size(), controlMask, inOutMask, carryMask,
+        modN, length, inOutStart, carryStart };
 
-    const size_t sizeDiff = sizeof(bitCapIntOcl) * ((controlLen * 2U) + length);
+    const size_t sizeDiff = sizeof(bitCapIntOcl) * ((controls.size() * 2U) + length);
     AddAlloc(sizeDiff);
     BufferPtr controlBuffer = MakeBuffer(CL_MEM_COPY_HOST_PTR | CL_MEM_READ_ONLY, sizeDiff, skipPowers.get());
     skipPowers.reset();

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -16,10 +16,10 @@
 
 namespace Qrack {
 
-inline bool IsPhase(const complex* mtrx) { return IS_NORM_0(mtrx[1]) && IS_NORM_0(mtrx[2]); }
-inline bool IsInvert(const complex* mtrx) { return IS_NORM_0(mtrx[0]) && IS_NORM_0(mtrx[3]); }
+inline bool IsPhase(complex const* mtrx) { return IS_NORM_0(mtrx[1]) && IS_NORM_0(mtrx[2]); }
+inline bool IsInvert(complex const* mtrx) { return IS_NORM_0(mtrx[0]) && IS_NORM_0(mtrx[3]); }
 
-bool QEngine::IsIdentity(const complex* mtrx, bool isControlled)
+bool QEngine::IsIdentity(complex const* mtrx, bool isControlled)
 {
     // If the effect of applying the buffer would be (approximately or exactly) that of applying the identity
     // operator, then we can discard this buffer without applying it.
@@ -222,7 +222,7 @@ bitCapInt QEngine::ForceM(const std::vector<bitLenInt>& bits, const std::vector<
     return result;
 }
 
-void QEngine::Mtrx(const complex* mtrx, bitLenInt qubit)
+void QEngine::Mtrx(complex const* mtrx, bitLenInt qubit)
 {
     if (IsIdentity(mtrx, false)) {
         return;
@@ -234,7 +234,7 @@ void QEngine::Mtrx(const complex* mtrx, bitLenInt qubit)
     Apply2x2(0U, qPowers[0U], mtrx, 1U, qPowers, doCalcNorm);
 }
 
-void QEngine::MCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
+void QEngine::MCMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target)
 {
     if (!controls.size()) {
         Mtrx(mtrx, target);
@@ -253,7 +253,7 @@ void QEngine::MCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx
     }
 }
 
-void QEngine::MACMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
+void QEngine::MACMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target)
 {
     if (!controls.size()) {
         Mtrx(mtrx, target);
@@ -417,7 +417,7 @@ void QEngine::AntiCISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt q
     Apply2x2(pow2Ocl(qubit1), pow2Ocl(qubit2), iSqrtX, controls.size() + 2U, qPowersSorted.get(), false);
 }
 
-void QEngine::ApplyControlled2x2(const std::vector<bitLenInt>& controls, bitLenInt target, const complex* mtrx)
+void QEngine::ApplyControlled2x2(const std::vector<bitLenInt>& controls, bitLenInt target, complex const* mtrx)
 {
     std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controls.size() + 1U]);
     const bitCapIntOcl targetMask = pow2Ocl(target);
@@ -433,7 +433,7 @@ void QEngine::ApplyControlled2x2(const std::vector<bitLenInt>& controls, bitLenI
     Apply2x2(controlMask, fullMask, mtrx, controls.size() + 1U, qPowersSorted.get(), false);
 }
 
-void QEngine::ApplyAntiControlled2x2(const std::vector<bitLenInt>& controls, bitLenInt target, const complex* mtrx)
+void QEngine::ApplyAntiControlled2x2(const std::vector<bitLenInt>& controls, bitLenInt target, complex const* mtrx)
 {
     std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controls.size() + 1U]);
     const bitCapIntOcl targetMask = pow2Ocl(target);

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -106,9 +106,9 @@ bool QEngine::ForceM(bitLenInt qubit, bool result, bool doForce, bool doApply)
 }
 
 /// Measure permutation state of a register
-bitCapInt QEngine::ForceM(bitLenInt const* bits, bitLenInt length, const bool* values, bool doApply)
+bitCapInt QEngine::ForceM(const std::vector<bitLenInt>& bits, const bool* values, bool doApply)
 {
-    for (bitLenInt i = 0U; i < length; ++i) {
+    for (bitLenInt i = 0U; i < bits.size(); ++i) {
         if (bits[i] >= qubitCount) {
             throw std::invalid_argument(
                 "QEngine::ForceM qubit index parameter array values must be within allocated qubit bounds!");
@@ -116,7 +116,7 @@ bitCapInt QEngine::ForceM(bitLenInt const* bits, bitLenInt length, const bool* v
     }
 
     // Single bit operations are better optimized for this special case:
-    if (length == 1U) {
+    if (bits.size() == 1U) {
         if (values == NULL) {
             if (M(bits[0U])) {
                 return pow2(bits[0U]);
@@ -136,13 +136,13 @@ bitCapInt QEngine::ForceM(bitLenInt const* bits, bitLenInt length, const bool* v
         NormalizeState();
     }
 
-    std::unique_ptr<bitCapInt[]> qPowers(new bitCapInt[length]);
+    std::unique_ptr<bitCapInt[]> qPowers(new bitCapInt[bits.size()]);
     bitCapInt regMask = 0U;
-    for (bitCapIntOcl i = 0U; i < length; ++i) {
+    for (bitCapIntOcl i = 0U; i < bits.size(); ++i) {
         qPowers[i] = pow2(bits[i]);
         regMask |= qPowers[i];
     }
-    std::sort(qPowers.get(), qPowers.get() + length);
+    std::sort(qPowers.get(), qPowers.get() + bits.size());
 
     const complex phase = GetNonunitaryPhase();
     real1 nrmlzr = ONE_R1;
@@ -150,7 +150,7 @@ bitCapInt QEngine::ForceM(bitLenInt const* bits, bitLenInt length, const bool* v
     complex nrm;
     if (values != NULL) {
         bitCapInt result = 0U;
-        for (bitLenInt j = 0U; j < length; ++j) {
+        for (bitLenInt j = 0U; j < bits.size(); ++j) {
             result |= values[j] ? pow2(bits[j]) : 0U;
         }
         nrmlzr = ProbMask(regMask, result);
@@ -163,7 +163,7 @@ bitCapInt QEngine::ForceM(bitLenInt const* bits, bitLenInt length, const bool* v
         return result;
     }
 
-    const bitCapIntOcl lengthPower = pow2Ocl(length);
+    const bitCapIntOcl lengthPower = pow2Ocl(bits.size());
     real1_f prob = Rand();
     std::unique_ptr<real1[]> probArray(new real1[lengthPower]());
 
@@ -199,7 +199,7 @@ bitCapInt QEngine::ForceM(bitLenInt const* bits, bitLenInt length, const bool* v
     probArray.reset();
 
     bitCapIntOcl i = 0U;
-    for (bitLenInt p = 0U; p < length; ++p) {
+    for (bitLenInt p = 0U; p < bits.size(); ++p) {
         if (pow2(p) & result) {
             i |= (bitCapIntOcl)qPowers[p];
         }
@@ -229,9 +229,9 @@ void QEngine::Mtrx(const complex* mtrx, bitLenInt qubit)
     Apply2x2(0U, qPowers[0U], mtrx, 1U, qPowers, doCalcNorm);
 }
 
-void QEngine::MCMtrx(bitLenInt const* controls, bitLenInt controlLen, const complex* mtrx, bitLenInt target)
+void QEngine::MCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         Mtrx(mtrx, target);
         return;
     }
@@ -242,15 +242,15 @@ void QEngine::MCMtrx(bitLenInt const* controls, bitLenInt controlLen, const comp
 
     const bool doCalcNorm = doNormalize && !(IsPhase(mtrx) || IsInvert(mtrx));
 
-    ApplyControlled2x2(controls, controlLen, target, mtrx);
+    ApplyControlled2x2(controls, target, mtrx);
     if (doCalcNorm) {
         UpdateRunningNorm();
     }
 }
 
-void QEngine::MACMtrx(bitLenInt const* controls, bitLenInt controlLen, const complex* mtrx, bitLenInt target)
+void QEngine::MACMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         Mtrx(mtrx, target);
         return;
     }
@@ -261,15 +261,15 @@ void QEngine::MACMtrx(bitLenInt const* controls, bitLenInt controlLen, const com
 
     const bool doCalcNorm = doNormalize && !(IsPhase(mtrx) || IsInvert(mtrx));
 
-    ApplyAntiControlled2x2(controls, controlLen, target, mtrx);
+    ApplyAntiControlled2x2(controls, target, mtrx);
     if (doCalcNorm) {
         UpdateRunningNorm();
     }
 }
 
-void QEngine::CSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2)
+void QEngine::CSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         Swap(qubit1, qubit2);
         return;
     }
@@ -280,21 +280,21 @@ void QEngine::CSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt q
 
     const complex pauliX[4U]{ ZERO_CMPLX, ONE_CMPLX, ONE_CMPLX, ZERO_CMPLX };
     bitCapIntOcl skipMask = 0U;
-    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controlLen + 2U]);
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controls.size() + 2U]);
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         qPowersSorted[i] = pow2Ocl(controls[i]);
         skipMask |= qPowersSorted[i];
     }
-    qPowersSorted[controlLen] = pow2Ocl(qubit1);
-    qPowersSorted[controlLen + 1U] = pow2Ocl(qubit2);
-    std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 2U);
-    Apply2x2(
-        skipMask | pow2Ocl(qubit1), skipMask | pow2Ocl(qubit2), pauliX, controlLen + 2U, qPowersSorted.get(), false);
+    qPowersSorted[controls.size()] = pow2Ocl(qubit1);
+    qPowersSorted[controls.size() + 1U] = pow2Ocl(qubit2);
+    std::sort(qPowersSorted.get(), qPowersSorted.get() + controls.size() + 2U);
+    Apply2x2(skipMask | pow2Ocl(qubit1), skipMask | pow2Ocl(qubit2), pauliX, controls.size() + 2U, qPowersSorted.get(),
+        false);
 }
 
-void QEngine::AntiCSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2)
+void QEngine::AntiCSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         Swap(qubit1, qubit2);
         return;
     }
@@ -304,19 +304,19 @@ void QEngine::AntiCSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenI
     }
 
     const complex pauliX[4U]{ ZERO_CMPLX, ONE_CMPLX, ONE_CMPLX, ZERO_CMPLX };
-    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controlLen + 2U]);
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controls.size() + 2U]);
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         qPowersSorted[i] = pow2Ocl(controls[i]);
     }
-    qPowersSorted[controlLen] = pow2Ocl(qubit1);
-    qPowersSorted[controlLen + 1U] = pow2Ocl(qubit2);
-    std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 2U);
-    Apply2x2(pow2Ocl(qubit1), pow2Ocl(qubit2), pauliX, controlLen + 2U, qPowersSorted.get(), false);
+    qPowersSorted[controls.size()] = pow2Ocl(qubit1);
+    qPowersSorted[controls.size() + 1U] = pow2Ocl(qubit2);
+    std::sort(qPowersSorted.get(), qPowersSorted.get() + controls.size() + 2U);
+    Apply2x2(pow2Ocl(qubit1), pow2Ocl(qubit2), pauliX, controls.size() + 2U, qPowersSorted.get(), false);
 }
 
-void QEngine::CSqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2)
+void QEngine::CSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         SqrtSwap(qubit1, qubit2);
         return;
     }
@@ -328,21 +328,21 @@ void QEngine::CSqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenI
     const complex sqrtX[4]{ complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f,
         complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f };
     bitCapIntOcl skipMask = 0U;
-    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controlLen + 2U]);
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controls.size() + 2U]);
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         qPowersSorted[i] = pow2Ocl(controls[i]);
         skipMask |= qPowersSorted[i];
     }
-    qPowersSorted[controlLen] = pow2Ocl(qubit1);
-    qPowersSorted[controlLen + 1U] = pow2Ocl(qubit2);
-    std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 2U);
-    Apply2x2(
-        skipMask | pow2Ocl(qubit1), skipMask | pow2Ocl(qubit2), sqrtX, controlLen + 2U, qPowersSorted.get(), false);
+    qPowersSorted[controls.size()] = pow2Ocl(qubit1);
+    qPowersSorted[controls.size() + 1U] = pow2Ocl(qubit2);
+    std::sort(qPowersSorted.get(), qPowersSorted.get() + controls.size() + 2U);
+    Apply2x2(skipMask | pow2Ocl(qubit1), skipMask | pow2Ocl(qubit2), sqrtX, controls.size() + 2U, qPowersSorted.get(),
+        false);
 }
 
-void QEngine::AntiCSqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2)
+void QEngine::AntiCSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         SqrtSwap(qubit1, qubit2);
         return;
     }
@@ -353,19 +353,19 @@ void QEngine::AntiCSqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bit
 
     const complex sqrtX[4]{ complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f,
         complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f };
-    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controlLen + 2U]);
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controls.size() + 2U]);
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         qPowersSorted[i] = pow2Ocl(controls[i]);
     }
-    qPowersSorted[controlLen] = pow2Ocl(qubit1);
-    qPowersSorted[controlLen + 1U] = pow2Ocl(qubit2);
-    std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 2U);
-    Apply2x2(pow2Ocl(qubit1), pow2Ocl(qubit2), sqrtX, controlLen + 2U, qPowersSorted.get(), false);
+    qPowersSorted[controls.size()] = pow2Ocl(qubit1);
+    qPowersSorted[controls.size() + 1U] = pow2Ocl(qubit2);
+    std::sort(qPowersSorted.get(), qPowersSorted.get() + controls.size() + 2U);
+    Apply2x2(pow2Ocl(qubit1), pow2Ocl(qubit2), sqrtX, controls.size() + 2U, qPowersSorted.get(), false);
 }
 
-void QEngine::CISqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2)
+void QEngine::CISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         ISqrtSwap(qubit1, qubit2);
         return;
     }
@@ -377,21 +377,21 @@ void QEngine::CISqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bitLen
     const complex iSqrtX[4]{ complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f,
         complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f };
     bitCapIntOcl skipMask = 0U;
-    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controlLen + 2U]);
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controls.size() + 2U]);
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         qPowersSorted[i] = pow2Ocl(controls[i]);
         skipMask |= qPowersSorted[i];
     }
-    qPowersSorted[controlLen] = pow2Ocl(qubit1);
-    qPowersSorted[controlLen + 1U] = pow2Ocl(qubit2);
-    std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 2U);
-    Apply2x2(
-        skipMask | pow2Ocl(qubit1), skipMask | pow2Ocl(qubit2), iSqrtX, controlLen + 2U, qPowersSorted.get(), false);
+    qPowersSorted[controls.size()] = pow2Ocl(qubit1);
+    qPowersSorted[controls.size() + 1U] = pow2Ocl(qubit2);
+    std::sort(qPowersSorted.get(), qPowersSorted.get() + controls.size() + 2U);
+    Apply2x2(skipMask | pow2Ocl(qubit1), skipMask | pow2Ocl(qubit2), iSqrtX, controls.size() + 2U, qPowersSorted.get(),
+        false);
 }
 
-void QEngine::AntiCISqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubit1, bitLenInt qubit2)
+void QEngine::AntiCISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         ISqrtSwap(qubit1, qubit2);
         return;
     }
@@ -402,43 +402,42 @@ void QEngine::AntiCISqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bi
 
     const complex iSqrtX[4U]{ complex(ONE_R1, -ONE_R1) / (real1)2.0f, complex(ONE_R1, ONE_R1) / (real1)2.0f,
         complex(ONE_R1, ONE_R1) / (real1)2.0f, complex(ONE_R1, -ONE_R1) / (real1)2.0f };
-    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controlLen + 2U]);
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controls.size() + 2U]);
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         qPowersSorted[i] = pow2Ocl(controls[i]);
     }
-    qPowersSorted[controlLen] = pow2Ocl(qubit1);
-    qPowersSorted[controlLen + 1U] = pow2Ocl(qubit2);
-    std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 2U);
-    Apply2x2(pow2Ocl(qubit1), pow2Ocl(qubit2), iSqrtX, controlLen + 2U, qPowersSorted.get(), false);
+    qPowersSorted[controls.size()] = pow2Ocl(qubit1);
+    qPowersSorted[controls.size() + 1U] = pow2Ocl(qubit2);
+    std::sort(qPowersSorted.get(), qPowersSorted.get() + controls.size() + 2U);
+    Apply2x2(pow2Ocl(qubit1), pow2Ocl(qubit2), iSqrtX, controls.size() + 2U, qPowersSorted.get(), false);
 }
 
-void QEngine::ApplyControlled2x2(bitLenInt const* controls, bitLenInt controlLen, bitLenInt target, const complex* mtrx)
+void QEngine::ApplyControlled2x2(const std::vector<bitLenInt>& controls, bitLenInt target, const complex* mtrx)
 {
-    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controlLen + 1U]);
+    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controls.size() + 1U]);
     const bitCapIntOcl targetMask = pow2Ocl(target);
     bitCapIntOcl fullMask = 0U;
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         qPowersSorted[i] = pow2Ocl(controls[i]);
         fullMask |= qPowersSorted[i];
     }
     const bitCapIntOcl controlMask = fullMask;
-    qPowersSorted[controlLen] = targetMask;
+    qPowersSorted[controls.size()] = targetMask;
     fullMask |= targetMask;
-    std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 1U);
-    Apply2x2(controlMask, fullMask, mtrx, controlLen + 1U, qPowersSorted.get(), false);
+    std::sort(qPowersSorted.get(), qPowersSorted.get() + controls.size() + 1U);
+    Apply2x2(controlMask, fullMask, mtrx, controls.size() + 1U, qPowersSorted.get(), false);
 }
 
-void QEngine::ApplyAntiControlled2x2(
-    bitLenInt const* controls, bitLenInt controlLen, bitLenInt target, const complex* mtrx)
+void QEngine::ApplyAntiControlled2x2(const std::vector<bitLenInt>& controls, bitLenInt target, const complex* mtrx)
 {
-    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controlLen + 1U]);
+    std::unique_ptr<bitCapIntOcl[]> qPowersSorted(new bitCapIntOcl[controls.size() + 1U]);
     const bitCapIntOcl targetMask = pow2Ocl(target);
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         qPowersSorted[i] = pow2Ocl(controls[i]);
     }
-    qPowersSorted[controlLen] = targetMask;
-    std::sort(qPowersSorted.get(), qPowersSorted.get() + controlLen + 1U);
-    Apply2x2(0U, targetMask, mtrx, controlLen + 1U, qPowersSorted.get(), false);
+    qPowersSorted[controls.size()] = targetMask;
+    std::sort(qPowersSorted.get(), qPowersSorted.get() + controls.size() + 1U);
+    Apply2x2(0U, targetMask, mtrx, controls.size() + 1U, qPowersSorted.get(), false);
 }
 
 /// Swap values of two bits in register
@@ -526,8 +525,8 @@ void QEngine::FSim(real1_f theta, real1_f phi, bitLenInt qubit1, bitLenInt qubit
         return;
     }
 
-    const bitLenInt controls[1U]{ qubit1 };
-    MCPhase(controls, 1U, ONE_CMPLX, exp(complex(ZERO_R1, (real1)phi)), qubit2);
+    const std::vector<bitLenInt> controls{ qubit1 };
+    MCPhase(controls, ONE_CMPLX, exp(complex(ZERO_R1, (real1)phi)), qubit2);
 }
 
 void QEngine::ProbRegAll(bitLenInt start, bitLenInt length, real1* probsArray)

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -106,8 +106,13 @@ bool QEngine::ForceM(bitLenInt qubit, bool result, bool doForce, bool doApply)
 }
 
 /// Measure permutation state of a register
-bitCapInt QEngine::ForceM(const std::vector<bitLenInt>& bits, const bool* values, bool doApply)
+bitCapInt QEngine::ForceM(const std::vector<bitLenInt>& bits, const std::vector<bool>& values, bool doApply)
 {
+    if (values.size() && (bits.size() != values.size())) {
+        throw std::invalid_argument(
+            "QInterface::ForceM() boolean values vector length does not match bit vector length!");
+    }
+
     for (bitLenInt i = 0U; i < bits.size(); ++i) {
         if (bits[i] >= qubitCount) {
             throw std::invalid_argument(
@@ -117,7 +122,7 @@ bitCapInt QEngine::ForceM(const std::vector<bitLenInt>& bits, const bool* values
 
     // Single bit operations are better optimized for this special case:
     if (bits.size() == 1U) {
-        if (values == NULL) {
+        if (!values.size()) {
             if (M(bits[0U])) {
                 return pow2(bits[0U]);
             } else {
@@ -148,7 +153,7 @@ bitCapInt QEngine::ForceM(const std::vector<bitLenInt>& bits, const bool* values
     real1 nrmlzr = ONE_R1;
     bitCapInt result;
     complex nrm;
-    if (values != NULL) {
+    if (values.size()) {
         bitCapInt result = 0U;
         for (bitLenInt j = 0U; j < bits.size(); ++j) {
             result |= values[j] ? pow2(bits[j]) : 0U;

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -564,7 +564,7 @@ void QEngineCPU::Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const comp
     std::shared_ptr<complex> mtrxS(new complex[4U], std::default_delete<complex[]>());
     std::copy(matrix, matrix + 4U, mtrxS.get());
 
-    std::shared_ptr<bitCapIntOcl> qPowersSorted(bitCount);
+    std::vector<bitCapIntOcl> qPowersSorted(bitCount);
     std::copy(qPowsSorted, qPowsSorted + bitCount, qPowersSorted.begin());
 
     const bool doApplyNorm = doNormalize && (bitCount == 1U) && (runningNorm > ZERO_R1);
@@ -657,7 +657,7 @@ void QEngineCPU::Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const comp
                 const bitCapIntOcl filterValues = filterMask & offset1 & offset2;
                 par_for_set(CastStateVecSparse()->iterable(setMask, filterMask, filterValues), fn);
             } else {
-                par_for_mask(0U, maxQPowerOcl, qPowersSorted, bitCount, fn);
+                par_for_mask(0U, maxQPowerOcl, qPowersSorted, fn);
             }
 
             if (doApplyNorm) {

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -95,7 +95,7 @@ void QEngineCPU::GetAmplitudePage(complex* pagePtr, bitCapIntOcl offset, bitCapI
         std::fill(pagePtr, pagePtr + length, ZERO_CMPLX);
     }
 }
-void QEngineCPU::SetAmplitudePage(const complex* pagePtr, bitCapIntOcl offset, bitCapIntOcl length)
+void QEngineCPU::SetAmplitudePage(complex const* pagePtr, bitCapIntOcl offset, bitCapIntOcl length)
 {
     if (isBadPermRange(offset, length, maxQPowerOcl)) {
         throw std::invalid_argument("QEngineCPU::SetAmplitudePage range is out-of-bounds!");
@@ -275,7 +275,7 @@ void QEngineCPU::SetPermutation(bitCapInt perm, complex phaseFac)
 }
 
 /// Set arbitrary pure quantum state, in unsigned int permutation basis
-void QEngineCPU::SetQuantumState(const complex* inputState)
+void QEngineCPU::SetQuantumState(complex const* inputState)
 {
     Dump();
 
@@ -356,7 +356,7 @@ void QEngineCPU::GetProbs(real1* outputProbs)
         stateVec->write2(lcv + offset1, qubit.c[0U], lcv + offset2, qubit.c[1U]);                                      \
     };
 
-void QEngineCPU::Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const complex* matrix, const bitLenInt bitCount,
+void QEngineCPU::Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, complex const* matrix, const bitLenInt bitCount,
     const bitCapIntOcl* qPowsSorted, bool doCalcNorm, real1_f nrm_thresh)
 {
     CHECK_ZERO_SKIP();
@@ -540,7 +540,7 @@ void QEngineCPU::Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const comp
         stateVec->write2(lcv + offset1, qubit[0U], lcv + offset2, qubit[1U]);                                          \
     };
 
-void QEngineCPU::Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const complex* matrix, const bitLenInt bitCount,
+void QEngineCPU::Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, complex const* matrix, const bitLenInt bitCount,
     const bitCapIntOcl* qPowsSorted, bool doCalcNorm, real1_f nrm_thresh)
 {
     CHECK_ZERO_SKIP();
@@ -777,7 +777,7 @@ void QEngineCPU::PhaseParity(real1_f radians, bitCapInt mask)
 }
 
 void QEngineCPU::UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls, bitLenInt qubitIndex,
-    const complex* mtrxs, bitCapInt const* mtrxSkipPowers, bitLenInt mtrxSkipLen, bitCapInt mtrxSkipValueMask)
+    complex const* mtrxs, bitCapInt const* mtrxSkipPowers, bitLenInt mtrxSkipLen, bitCapInt mtrxSkipValueMask)
 {
     CHECK_ZERO_SKIP();
 

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -778,8 +778,9 @@ void QEngineCPU::PhaseParity(real1_f radians, bitCapInt mask)
     });
 }
 
-void QEngineCPU::UniformlyControlledSingleBit(const bitLenInt* controls, bitLenInt controlLen, bitLenInt qubitIndex,
-    const complex* mtrxs, const bitCapInt* mtrxSkipPowers, bitLenInt mtrxSkipLen, bitCapInt mtrxSkipValueMask)
+void QEngineCPU::UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls, bitLenInt controlLen,
+    bitLenInt qubitIndex, const complex* mtrxs, const std::vector<bitCapInt>& mtrxSkipPowers,
+    bitCapInt mtrxSkipValueMask)
 {
     CHECK_ZERO_SKIP();
 
@@ -893,7 +894,8 @@ void QEngineCPU::UniformParityRZ(bitCapInt mask, real1_f angle)
     });
 }
 
-void QEngineCPU::CUniformParityRZ(const bitLenInt* cControls, bitLenInt controlLen, bitCapInt mask, real1_f angle)
+void QEngineCPU::CUniformParityRZ(
+    const std::vector<bitLenInt>& cControls, bitLenInt controlLen, bitCapInt mask, real1_f angle)
 {
     if (!controlLen) {
         return UniformParityRZ(mask, angle);

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -380,8 +380,8 @@ void QEngineCPU::Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const comp
     std::shared_ptr<complex> mtrxS(new complex[4U], std::default_delete<complex[]>());
     std::copy(matrix, matrix + 4U, mtrxS.get());
 
-    std::shared_ptr<bitCapIntOcl> qPowersSortedS(new bitCapIntOcl[bitCount], std::default_delete<bitCapIntOcl[]>());
-    std::copy(qPowsSorted, qPowsSorted + bitCount, qPowersSortedS.get());
+    std::vector<bitCapIntOcl> qPowersSorted(bitCount);
+    std::copy(qPowsSorted, qPowsSorted + bitCount, qPowersSorted.begin());
 
     const bool doApplyNorm = doNormalize && (bitCount == 1U) && (runningNorm > ZERO_R1);
     doCalcNorm = doCalcNorm && (doApplyNorm || (runningNorm <= ZERO_R1));
@@ -393,9 +393,8 @@ void QEngineCPU::Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const comp
     }
 
     Dispatch(maxQPower >> bitCount,
-        [this, mtrxS, qPowersSortedS, offset1, offset2, bitCount, doCalcNorm, doApplyNorm, nrm, nrm_thresh] {
+        [this, mtrxS, qPowersSorted, offset1, offset2, bitCount, doCalcNorm, doApplyNorm, nrm, nrm_thresh] {
             complex* mtrx = mtrxS.get();
-            const bitCapIntOcl* qPowersSorted = qPowersSortedS.get();
 
             const real1_f norm_thresh = (nrm_thresh < ZERO_R1) ? amplitudeFloor : nrm_thresh;
             const unsigned numCores = GetConcurrencyLevel();
@@ -475,7 +474,7 @@ void QEngineCPU::Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const comp
                 const bitCapIntOcl filterValues = filterMask & offset1 & offset2;
                 par_for_set(CastStateVecSparse()->iterable(setMask, filterMask, filterValues), fn);
             } else {
-                par_for_mask(0U, maxQPowerOcl, qPowersSorted, bitCount, fn);
+                par_for_mask(0U, maxQPowerOcl, qPowersSorted, fn);
             }
 
             if (doApplyNorm) {
@@ -565,8 +564,8 @@ void QEngineCPU::Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const comp
     std::shared_ptr<complex> mtrxS(new complex[4U], std::default_delete<complex[]>());
     std::copy(matrix, matrix + 4U, mtrxS.get());
 
-    std::shared_ptr<bitCapIntOcl> qPowersSortedS(new bitCapIntOcl[bitCount], std::default_delete<bitCapIntOcl[]>());
-    std::copy(qPowsSorted, qPowsSorted + bitCount, qPowersSortedS.get());
+    std::shared_ptr<bitCapIntOcl> qPowersSorted(bitCount);
+    std::copy(qPowsSorted, qPowsSorted + bitCount, qPowersSorted.begin());
 
     const bool doApplyNorm = doNormalize && (bitCount == 1U) && (runningNorm > ZERO_R1);
     doCalcNorm = doCalcNorm && (doApplyNorm || (runningNorm <= ZERO_R1));
@@ -578,13 +577,12 @@ void QEngineCPU::Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const comp
     }
 
     Dispatch(maxQPower >> bitCount,
-        [this, mtrxS, qPowersSortedS, offset1, offset2, bitCount, doCalcNorm, doApplyNorm, nrm, nrm_thresh] {
+        [this, mtrxS, qPowersSorted, offset1, offset2, bitCount, doCalcNorm, doApplyNorm, nrm, nrm_thresh] {
             complex* mtrx = mtrxS.get();
             const complex mtrx0 = mtrx[0U];
             const complex mtrx1 = mtrx[1U];
             const complex mtrx2 = mtrx[2U];
             const complex mtrx3 = mtrx[3U];
-            const bitCapIntOcl* qPowersSorted = qPowersSortedS.get();
 
             const real1 norm_thresh = (nrm_thresh < ZERO_R1) ? amplitudeFloor : (real1)nrm_thresh;
             const unsigned numCores = GetConcurrencyLevel();
@@ -778,14 +776,13 @@ void QEngineCPU::PhaseParity(real1_f radians, bitCapInt mask)
     });
 }
 
-void QEngineCPU::UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls, bitLenInt controlLen,
-    bitLenInt qubitIndex, const complex* mtrxs, const std::vector<bitCapInt>& mtrxSkipPowers,
-    bitCapInt mtrxSkipValueMask)
+void QEngineCPU::UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls, bitLenInt qubitIndex,
+    const complex* mtrxs, bitCapInt const* mtrxSkipPowers, bitLenInt mtrxSkipLen, bitCapInt mtrxSkipValueMask)
 {
     CHECK_ZERO_SKIP();
 
     // If there are no controls, the base case should be the non-controlled single bit gate.
-    if (!controlLen) {
+    if (!controls.size()) {
         Mtrx(mtrxs + (bitCapIntOcl)(mtrxSkipValueMask * 4U), qubitIndex);
         return;
     }
@@ -794,15 +791,14 @@ void QEngineCPU::UniformlyControlledSingleBit(const std::vector<bitLenInt>& cont
         throw std::invalid_argument("QEngineCPU::UniformlyControlledSingleBit qubitIndex is out-of-bounds!");
     }
 
-    ThrowIfQbIdArrayIsBad(
-        controls, controlLen, qubitCount, "QEngineCPU::UniformlyControlledSingleBit control is out-of-bounds!");
+    ThrowIfQbIdArrayIsBad(controls, qubitCount, "QEngineCPU::UniformlyControlledSingleBit control is out-of-bounds!");
 
     const bitCapIntOcl targetPower = pow2Ocl(qubitIndex);
 
     const real1 nrm = (runningNorm > ZERO_R1) ? ONE_R1 / (real1)sqrt(runningNorm) : ONE_R1;
 
-    std::unique_ptr<bitCapIntOcl[]> qPowers(new bitCapIntOcl[controlLen]);
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    std::unique_ptr<bitCapIntOcl[]> qPowers(new bitCapIntOcl[controls.size()]);
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         qPowers[i] = pow2Ocl(controls[i]);
     }
 
@@ -820,7 +816,7 @@ void QEngineCPU::UniformlyControlledSingleBit(const std::vector<bitLenInt>& cont
 
     par_for_skip(0U, maxQPowerOcl, targetPower, 1U, [&](const bitCapIntOcl& lcv, const unsigned& cpu) {
         bitCapIntOcl offset = 0U;
-        for (bitLenInt j = 0U; j < controlLen; ++j) {
+        for (bitLenInt j = 0U; j < controls.size(); ++j) {
             if (lcv & qPowers[j]) {
                 offset |= pow2Ocl(j);
             }
@@ -894,10 +890,9 @@ void QEngineCPU::UniformParityRZ(bitCapInt mask, real1_f angle)
     });
 }
 
-void QEngineCPU::CUniformParityRZ(
-    const std::vector<bitLenInt>& cControls, bitLenInt controlLen, bitCapInt mask, real1_f angle)
+void QEngineCPU::CUniformParityRZ(const std::vector<bitLenInt>& cControls, bitCapInt mask, real1_f angle)
 {
-    if (!controlLen) {
+    if (!cControls.size()) {
         return UniformParityRZ(mask, angle);
     }
 
@@ -905,17 +900,17 @@ void QEngineCPU::CUniformParityRZ(
         throw std::invalid_argument("QEngineCPU::CUniformParityRZ mask out-of-bounds!");
     }
 
-    ThrowIfQbIdArrayIsBad(cControls, controlLen, qubitCount, "QEngineCPU::CUniformParityRZ control is out-of-bounds!");
+    ThrowIfQbIdArrayIsBad(cControls, qubitCount, "QEngineCPU::CUniformParityRZ control is out-of-bounds!");
 
     CHECK_ZERO_SKIP();
 
-    std::vector<bitLenInt> controls(cControls, cControls + controlLen);
+    std::vector<bitLenInt> controls(cControls.begin(), cControls.end());
     std::sort(controls.begin(), controls.end());
 
-    Dispatch(maxQPower >> controlLen, [this, controls, mask, angle] {
+    Dispatch(maxQPower >> cControls.size(), [this, controls, mask, angle] {
         bitCapIntOcl controlMask = 0U;
-        std::unique_ptr<bitCapIntOcl[]> controlPowers(new bitCapIntOcl[controls.size()]);
-        for (bitLenInt i = 0U; i < (bitLenInt)controls.size(); ++i) {
+        std::vector<bitCapIntOcl> controlPowers(controls.size());
+        for (size_t i = 0U; i < controls.size(); ++i) {
             controlPowers[i] = pow2Ocl(controls[i]);
             controlMask |= controlPowers[i];
         }
@@ -937,7 +932,7 @@ void QEngineCPU::CUniformParityRZ(
             stateVec->write(controlMask | lcv, stateVec->read(controlMask | lcv) * ((c & 1U) ? phaseFac : phaseFacAdj));
         };
 
-        par_for_mask(0U, maxQPowerOcl, controlPowers.get(), controls.size(), fn);
+        par_for_mask(0U, maxQPowerOcl, controlPowers, fn);
     });
 }
 
@@ -1507,21 +1502,18 @@ real1_f QEngineCPU::ProbMask(bitCapInt mask, bitCapInt permutation)
         skipPowersVec.push_back((v ^ oldV) & oldV);
     }
 
-    std::unique_ptr<bitCapIntOcl[]> skipPowers(new bitCapIntOcl[length]);
-    std::copy(skipPowersVec.begin(), skipPowersVec.end(), skipPowers.get());
+    std::vector<bitCapIntOcl> skipPowers(length);
+    std::copy(skipPowersVec.begin(), skipPowersVec.end(), skipPowers.begin());
 
     const unsigned num_threads = GetConcurrencyLevel();
     std::unique_ptr<real1[]> probs(new real1[num_threads]());
 
     const bitCapIntOcl permutationOcl = (bitCapIntOcl)permutation;
     stateVec->isReadLocked = false;
-    par_for_mask(
-        0U, maxQPowerOcl, skipPowers.get(), skipPowersVec.size(), [&](const bitCapIntOcl& lcv, const unsigned& cpu) {
-            probs[cpu] += norm(stateVec->read(lcv | permutationOcl));
-        });
+    par_for_mask(0U, maxQPowerOcl, skipPowers, [&](const bitCapIntOcl& lcv, const unsigned& cpu) {
+        probs[cpu] += norm(stateVec->read(lcv | permutationOcl));
+    });
     stateVec->isReadLocked = true;
-
-    skipPowers.reset();
 
     real1 prob = ZERO_R1;
     for (unsigned thrd = 0; thrd < num_threads; ++thrd) {

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -22,7 +22,7 @@
 #define GATE_1_BIT(gate, mtrx00, mtrx01, mtrx10, mtrx11)                                                               \
     void QInterface::gate(bitLenInt qubit)                                                                             \
     {                                                                                                                  \
-        const complex mtrx[4] = { mtrx00, mtrx01, mtrx10, mtrx11 };                                                    \
+        const complex mtrx[4]{ mtrx00, mtrx01, mtrx10, mtrx11 };                                                       \
         Mtrx(mtrx, qubit);                                                                                             \
     }
 
@@ -156,103 +156,103 @@ void QInterface::CIT(bitLenInt control, bitLenInt target) { CIPhaseRootN(3U, con
 /// Controlled not
 void QInterface::CNOT(bitLenInt control, bitLenInt target)
 {
-    const bitLenInt controls[1] = { control };
-    MCInvert(controls, 1, ONE_CMPLX, ONE_CMPLX, target);
+    const std::vector<bitLenInt> controls{ control };
+    MCInvert(controls, ONE_CMPLX, ONE_CMPLX, target);
 }
 
 /// Apply controlled Pauli Y matrix to bit
 void QInterface::CY(bitLenInt control, bitLenInt target)
 {
-    const bitLenInt controls[1] = { control };
-    MCInvert(controls, 1, -I_CMPLX, I_CMPLX, target);
+    const std::vector<bitLenInt> controls{ control };
+    MCInvert(controls, -I_CMPLX, I_CMPLX, target);
 }
 
 /// Apply doubly-controlled Pauli Z matrix to bit
 void QInterface::CCY(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
-    const bitLenInt controls[2] = { control1, control2 };
-    MCInvert(controls, 2, -I_CMPLX, I_CMPLX, target);
+    const std::vector<bitLenInt> controls{ control1, control2 };
+    MCInvert(controls, -I_CMPLX, I_CMPLX, target);
 }
 
 /// "Anti-doubly-controlled Y" - Apply Pauli Y if control bits are both zero, do not apply if either control bit is one.
 void QInterface::AntiCCY(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
-    const bitLenInt controls[2] = { control1, control2 };
-    MACInvert(controls, 2, -I_CMPLX, I_CMPLX, target);
+    const std::vector<bitLenInt> controls{ control1, control2 };
+    MACInvert(controls, -I_CMPLX, I_CMPLX, target);
 }
 
 /// "Anti-controlled not" - Apply "not" if control bit is zero, do not apply if control bit is one.
 void QInterface::AntiCY(bitLenInt control, bitLenInt target)
 {
-    const bitLenInt controls[1] = { control };
-    MACInvert(controls, 1, -I_CMPLX, I_CMPLX, target);
+    const std::vector<bitLenInt> controls{ control };
+    MACInvert(controls, -I_CMPLX, I_CMPLX, target);
 }
 
 /// Apply controlled Pauli Z matrix to bit
 void QInterface::CZ(bitLenInt control, bitLenInt target)
 {
-    const bitLenInt controls[1] = { control };
-    MCPhase(controls, 1, ONE_CMPLX, -ONE_CMPLX, target);
+    const std::vector<bitLenInt> controls{ control };
+    MCPhase(controls, ONE_CMPLX, -ONE_CMPLX, target);
 }
 
 /// Apply doubly-controlled Pauli Z matrix to bit
 void QInterface::CCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
-    const bitLenInt controls[2] = { control1, control2 };
-    MCPhase(controls, 2, ONE_CMPLX, -ONE_CMPLX, target);
+    const std::vector<bitLenInt> controls{ control1, control2 };
+    MCPhase(controls, ONE_CMPLX, -ONE_CMPLX, target);
 }
 
 /// "Anti-doubly-controlled Z" - Apply Pauli Z if control bits are both zero, do not apply if either control bit is one.
 void QInterface::AntiCCZ(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
-    const bitLenInt controls[2] = { control1, control2 };
-    MACPhase(controls, 2, ONE_CMPLX, -ONE_CMPLX, target);
+    const std::vector<bitLenInt> controls{ control1, control2 };
+    MACPhase(controls, ONE_CMPLX, -ONE_CMPLX, target);
 }
 
 /// "Anti-controlled Z" - Apply Pauli Z if control bit is zero, do not apply if control bit is one.
 void QInterface::AntiCZ(bitLenInt control, bitLenInt target)
 {
-    const bitLenInt controls[1] = { control };
-    MACPhase(controls, 1, ONE_CMPLX, -ONE_CMPLX, target);
+    const std::vector<bitLenInt> controls{ control };
+    MACPhase(controls, ONE_CMPLX, -ONE_CMPLX, target);
 }
 
 /// Apply controlled Hadamard matrix to bit
 void QInterface::CH(bitLenInt control, bitLenInt target)
 {
-    const bitLenInt controls[1] = { control };
-    const complex h[4] = { complex(ONE_R1 / SQRT2_R1, ZERO_R1), complex(ONE_R1 / SQRT2_R1, ZERO_R1),
+    const std::vector<bitLenInt> controls{ control };
+    const complex h[4]{ complex(ONE_R1 / SQRT2_R1, ZERO_R1), complex(ONE_R1 / SQRT2_R1, ZERO_R1),
         complex(ONE_R1 / SQRT2_R1, ZERO_R1), complex(-ONE_R1 / SQRT2_R1, ZERO_R1) };
-    MCMtrx(controls, 1, h, target);
+    MCMtrx(controls, h, target);
 }
 
 /// Apply (anti-)controlled Hadamard matrix to bit
 void QInterface::AntiCH(bitLenInt control, bitLenInt target)
 {
-    const bitLenInt controls[1] = { control };
-    const complex h[4] = { complex(ONE_R1 / SQRT2_R1, ZERO_R1), complex(ONE_R1 / SQRT2_R1, ZERO_R1),
+    const std::vector<bitLenInt> controls{ control };
+    const complex h[4]{ complex(ONE_R1 / SQRT2_R1, ZERO_R1), complex(ONE_R1 / SQRT2_R1, ZERO_R1),
         complex(ONE_R1 / SQRT2_R1, ZERO_R1), complex(-ONE_R1 / SQRT2_R1, ZERO_R1) };
-    MACMtrx(controls, 1, h, target);
+    MACMtrx(controls, h, target);
 }
 
 /// Doubly-controlled not
 void QInterface::CCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
-    const bitLenInt controls[2] = { control1, control2 };
-    MCInvert(controls, 2, ONE_CMPLX, ONE_CMPLX, target);
+    const std::vector<bitLenInt> controls{ control1, control2 };
+    MCInvert(controls, ONE_CMPLX, ONE_CMPLX, target);
 }
 
 /// "Anti-doubly-controlled not" - Apply "not" if control bits are both zero, do not apply if either control bit is one.
 void QInterface::AntiCCNOT(bitLenInt control1, bitLenInt control2, bitLenInt target)
 {
-    const bitLenInt controls[2] = { control1, control2 };
-    MACInvert(controls, 2, ONE_CMPLX, ONE_CMPLX, target);
+    const std::vector<bitLenInt> controls{ control1, control2 };
+    MACInvert(controls, ONE_CMPLX, ONE_CMPLX, target);
 }
 
 /// "Anti-controlled not" - Apply "not" if control bit is zero, do not apply if control bit is one.
 void QInterface::AntiCNOT(bitLenInt control, bitLenInt target)
 {
-    const bitLenInt controls[1] = { control };
-    MACInvert(controls, 1, ONE_CMPLX, ONE_CMPLX, target);
+    const std::vector<bitLenInt> controls{ control };
+    MACInvert(controls, ONE_CMPLX, ONE_CMPLX, target);
 }
 
 /// Apply controlled "PhaseRootN" gate to bit
@@ -266,18 +266,18 @@ void QInterface::CPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
         return;
     }
 
-    const bitLenInt controls[1] = { control };
+    const std::vector<bitLenInt> controls{ control };
 
     if (n == 2) {
-        MCPhase(controls, 1, ONE_CMPLX, I_CMPLX, target);
+        MCPhase(controls, ONE_CMPLX, I_CMPLX, target);
         return;
     }
     if (n == 3) {
-        MCPhase(controls, 1, ONE_CMPLX, C_SQRT_I, target);
+        MCPhase(controls, ONE_CMPLX, C_SQRT_I, target);
         return;
     }
 
-    MCPhase(controls, 1, ONE_CMPLX, pow(-ONE_CMPLX, (complex)((real1)(ONE_R1 / (bitCapIntOcl)(pow2(n - 1U))))), target);
+    MCPhase(controls, ONE_CMPLX, pow(-ONE_CMPLX, (complex)((real1)(ONE_R1 / (bitCapIntOcl)(pow2(n - 1U))))), target);
 }
 
 /// Apply controlled "IPhaseRootN" gate to bit
@@ -291,19 +291,18 @@ void QInterface::CIPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt target)
         return;
     }
 
-    const bitLenInt controls[1] = { control };
+    const std::vector<bitLenInt> controls{ control };
 
     if (n == 2) {
-        MCPhase(controls, 1, ONE_CMPLX, -I_CMPLX, target);
+        MCPhase(controls, ONE_CMPLX, -I_CMPLX, target);
         return;
     }
     if (n == 3) {
-        MCPhase(controls, 1, ONE_CMPLX, C_SQRT_N_I, target);
+        MCPhase(controls, ONE_CMPLX, C_SQRT_N_I, target);
         return;
     }
 
-    MCPhase(
-        controls, 1, ONE_CMPLX, pow(-ONE_CMPLX, (complex)((real1)(-ONE_R1 / (bitCapIntOcl)(pow2(n - 1U))))), target);
+    MCPhase(controls, ONE_CMPLX, pow(-ONE_CMPLX, (complex)((real1)(-ONE_R1 / (bitCapIntOcl)(pow2(n - 1U))))), target);
 }
 
 /// Apply (anti-)controlled "PhaseRootN" gate to bit
@@ -317,19 +316,18 @@ void QInterface::AntiCPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt targe
         return;
     }
 
-    const bitLenInt controls[1] = { control };
+    const std::vector<bitLenInt> controls{ control };
 
     if (n == 2) {
-        MACPhase(controls, 1, ONE_CMPLX, I_CMPLX, target);
+        MACPhase(controls, ONE_CMPLX, I_CMPLX, target);
         return;
     }
     if (n == 3) {
-        MACPhase(controls, 1, ONE_CMPLX, C_SQRT_I, target);
+        MACPhase(controls, ONE_CMPLX, C_SQRT_I, target);
         return;
     }
 
-    MACPhase(
-        controls, 1, ONE_CMPLX, pow(-ONE_CMPLX, (complex)((real1)(ONE_R1 / (bitCapIntOcl)(pow2(n - 1U))))), target);
+    MACPhase(controls, ONE_CMPLX, pow(-ONE_CMPLX, (complex)((real1)(ONE_R1 / (bitCapIntOcl)(pow2(n - 1U))))), target);
 }
 
 /// Apply (anti-)controlled "IPhaseRootN" gate to bit
@@ -343,41 +341,40 @@ void QInterface::AntiCIPhaseRootN(bitLenInt n, bitLenInt control, bitLenInt targ
         return;
     }
 
-    const bitLenInt controls[1] = { control };
+    const std::vector<bitLenInt> controls{ control };
 
     if (n == 2) {
-        MACPhase(controls, 1, ONE_CMPLX, -I_CMPLX, target);
+        MACPhase(controls, ONE_CMPLX, -I_CMPLX, target);
         return;
     }
     if (n == 3) {
-        MACPhase(controls, 1, ONE_CMPLX, C_SQRT_N_I, target);
+        MACPhase(controls, ONE_CMPLX, C_SQRT_N_I, target);
         return;
     }
 
-    MACPhase(
-        controls, 1, ONE_CMPLX, pow(-ONE_CMPLX, (complex)((real1)(-ONE_R1 / (bitCapIntOcl)(pow2(n - 1U))))), target);
+    MACPhase(controls, ONE_CMPLX, pow(-ONE_CMPLX, (complex)((real1)(-ONE_R1 / (bitCapIntOcl)(pow2(n - 1U))))), target);
 }
 
-void QInterface::UniformlyControlledSingleBit(bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubitIndex,
-    complex const* mtrxs, bitCapInt const* mtrxSkipPowers, bitLenInt mtrxSkipLen, bitCapInt mtrxSkipValueMask)
+void QInterface::UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls, bitLenInt qubitIndex,
+    complex const* mtrxs, const std::vector<bitCapInt>& mtrxSkipPowers, bitCapInt mtrxSkipValueMask)
 {
-    for (bitLenInt bit_pos = 0U; bit_pos < controlLen; ++bit_pos) {
+    for (bitLenInt bit_pos = 0U; bit_pos < controls.size(); ++bit_pos) {
         X(controls[bit_pos]);
     }
-    const bitCapInt maxI = pow2(controlLen) - ONE_BCI;
+    const bitCapInt maxI = pow2(controls.size()) - ONE_BCI;
     for (bitCapInt lcv = 0U; lcv < maxI; ++lcv) {
-        const bitCapInt index = pushApartBits(lcv, mtrxSkipPowers, mtrxSkipLen) | mtrxSkipValueMask;
-        MCMtrx(controls, controlLen, mtrxs + (bitCapIntOcl)(index * 4U), qubitIndex);
+        const bitCapInt index = pushApartBits(lcv, mtrxSkipPowers) | mtrxSkipValueMask;
+        MCMtrx(controls, mtrxs + (bitCapIntOcl)(index * 4U), qubitIndex);
 
         const bitCapInt lcvDiff = lcv ^ (lcv + ONE_BCI);
-        for (bitLenInt bit_pos = 0U; bit_pos < controlLen; ++bit_pos) {
+        for (bitLenInt bit_pos = 0U; bit_pos < controls.size(); ++bit_pos) {
             if ((lcvDiff >> bit_pos) & ONE_BCI) {
                 X(controls[bit_pos]);
             }
         }
     }
-    const bitCapInt index = pushApartBits(maxI, mtrxSkipPowers, mtrxSkipLen) | mtrxSkipValueMask;
-    MCMtrx(controls, controlLen, mtrxs + (bitCapIntOcl)(index * 4U), qubitIndex);
+    const bitCapInt index = pushApartBits(maxI, mtrxSkipPowers) | mtrxSkipValueMask;
+    MCMtrx(controls, mtrxs + (bitCapIntOcl)(index * 4U), qubitIndex);
 }
 
 void QInterface::PhaseFlip() { Phase(-ONE_CMPLX, -ONE_CMPLX, 0); }
@@ -393,12 +390,11 @@ void QInterface::ZeroPhaseFlip(bitLenInt start, bitLenInt length)
         return;
     }
 
-    const bitLenInt min1 = length - 1U;
-    std::unique_ptr<bitLenInt[]> controls(new bitLenInt[min1]);
-    for (bitLenInt i = 0U; i < min1; ++i) {
+    std::vector<bitLenInt> controls(length - 1U);
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         controls[i] = start + i;
     }
-    MACPhase(controls.get(), min1, -ONE_CMPLX, ONE_CMPLX, start + min1);
+    MACPhase(controls, -ONE_CMPLX, ONE_CMPLX, start + controls.size());
 }
 
 void QInterface::XMask(bitCapInt mask)
@@ -533,9 +529,9 @@ void QInterface::ISqrtSwap(bitLenInt q1, bitLenInt q2)
     CNOT(q1, q2);
 }
 
-void QInterface::CSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt q1, bitLenInt q2)
+void QInterface::CSwap(const std::vector<bitLenInt>& controls, bitLenInt q1, bitLenInt q2)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         Swap(q1, q2);
         return;
     }
@@ -544,34 +540,34 @@ void QInterface::CSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenIn
         return;
     }
 
-    std::unique_ptr<bitLenInt[]> lControls(new bitLenInt[controlLen + 1U]());
-    std::copy(controls, controls + controlLen, lControls.get());
+    std::vector<bitLenInt> lControls(controls.size() + 1U);
+    std::copy(controls.begin(), controls.end(), lControls.begin());
 
-    lControls[controlLen] = q1;
-    MCInvert(lControls.get(), controlLen + 1U, ONE_CMPLX, ONE_CMPLX, q2);
+    lControls[controls.size()] = q1;
+    MCInvert(lControls, ONE_CMPLX, ONE_CMPLX, q2);
 
-    lControls[controlLen] = q2;
-    MCInvert(lControls.get(), controlLen + 1U, ONE_CMPLX, ONE_CMPLX, q1);
+    lControls[controls.size()] = q2;
+    MCInvert(lControls, ONE_CMPLX, ONE_CMPLX, q1);
 
-    lControls[controlLen] = q1;
-    MCInvert(lControls.get(), controlLen + 1U, ONE_CMPLX, ONE_CMPLX, q2);
+    lControls[controls.size()] = q1;
+    MCInvert(lControls, ONE_CMPLX, ONE_CMPLX, q2);
 }
 
-void QInterface::AntiCSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt q1, bitLenInt q2)
+void QInterface::AntiCSwap(const std::vector<bitLenInt>& controls, bitLenInt q1, bitLenInt q2)
 {
     bitCapInt m = 0U;
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         m |= pow2(controls[i]);
     }
 
     XMask(m);
-    CSwap(controls, controlLen, q1, q2);
+    CSwap(controls, q1, q2);
     XMask(m);
 }
 
-void QInterface::CSqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt q1, bitLenInt q2)
+void QInterface::CSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt q1, bitLenInt q2)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         SqrtSwap(q1, q2);
         return;
     }
@@ -581,110 +577,110 @@ void QInterface::CSqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bitL
     }
 
     // https://quantumcomputing.stackexchange.com/questions/2228/how-to-implement-the-square-root-of-swap-gate-on-the-ibm-q-composer
-    std::unique_ptr<bitLenInt[]> lControls(new bitLenInt[controlLen + 1U]);
-    std::copy(controls, controls + controlLen, lControls.get());
-    lControls[controlLen] = q1;
+    std::vector<bitLenInt> lControls(controls.size() + 1U);
+    std::copy(controls.begin(), controls.end(), lControls.begin());
+    lControls[controls.size()] = q1;
 
-    MCInvert(lControls.get(), controlLen + 1U, ONE_CMPLX, ONE_CMPLX, q2);
+    MCInvert(lControls, ONE_CMPLX, ONE_CMPLX, q2);
 
-    const complex had[4] = { C_SQRT1_2, C_SQRT1_2, C_SQRT1_2, -C_SQRT1_2 };
-    MCMtrx(lControls.get(), controlLen, had, q1);
+    const complex had[4]{ C_SQRT1_2, C_SQRT1_2, C_SQRT1_2, -C_SQRT1_2 };
+    MCMtrx(controls, had, q1);
 
-    const complex it[4] = { ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, C_SQRT_N_I };
-    MCMtrx(lControls.get(), controlLen, it, q2);
+    const complex it[4]{ ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, C_SQRT_N_I };
+    MCMtrx(controls, it, q2);
 
-    const complex t[4] = { ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, C_SQRT_I };
-    MCMtrx(lControls.get(), controlLen, t, q1);
+    const complex t[4]{ ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, C_SQRT_I };
+    MCMtrx(controls, t, q1);
 
-    MCMtrx(lControls.get(), controlLen, had, q2);
+    MCMtrx(controls, had, q2);
 
-    MCMtrx(lControls.get(), controlLen, had, q1);
+    MCMtrx(controls, had, q1);
 
-    MCInvert(lControls.get(), controlLen + 1U, ONE_CMPLX, ONE_CMPLX, q2);
+    MCInvert(lControls, ONE_CMPLX, ONE_CMPLX, q2);
 
-    MCMtrx(lControls.get(), controlLen, had, q1);
+    MCMtrx(controls, had, q1);
 
-    MCMtrx(lControls.get(), controlLen, had, q2);
+    MCMtrx(controls, had, q2);
 
-    MCMtrx(lControls.get(), controlLen, it, q1);
+    MCMtrx(controls, it, q1);
 
-    MCMtrx(lControls.get(), controlLen, had, q1);
+    MCMtrx(controls, had, q1);
 
-    MCInvert(lControls.get(), controlLen + 1U, ONE_CMPLX, ONE_CMPLX, q2);
+    MCInvert(lControls, ONE_CMPLX, ONE_CMPLX, q2);
 
-    const complex is[4] = { ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, -I_CMPLX };
-    MCMtrx(lControls.get(), controlLen, is, q1);
+    const complex is[4]{ ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, -I_CMPLX };
+    MCMtrx(controls, is, q1);
 
-    const complex s[4] = { ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, I_CMPLX };
-    MCMtrx(lControls.get(), controlLen, s, q2);
+    const complex s[4]{ ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, I_CMPLX };
+    MCMtrx(controls, s, q2);
 }
 
-void QInterface::CISqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt q1, bitLenInt q2)
+void QInterface::CISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt q1, bitLenInt q2)
 {
     if (q1 == q2) {
         return;
     }
 
     // https://quantumcomputing.stackexchange.com/questions/2228/how-to-implement-the-square-root-of-swap-gate-on-the-ibm-q-composer
-    std::unique_ptr<bitLenInt[]> lControls(new bitLenInt[controlLen + 1U]);
-    std::copy(controls, controls + controlLen, lControls.get());
-    lControls[controlLen] = q1;
+    std::vector<bitLenInt> lControls(controls.size() + 1U);
+    std::copy(controls.begin(), controls.end(), lControls.begin());
+    lControls[controls.size()] = q1;
 
-    const complex is[4] = { ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, -I_CMPLX };
-    MCMtrx(lControls.get(), controlLen, is, q2);
+    const complex is[4]{ ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, -I_CMPLX };
+    MCMtrx(controls, is, q2);
 
-    const complex s[4] = { ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, I_CMPLX };
-    MCMtrx(lControls.get(), controlLen, s, q1);
+    const complex s[4]{ ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, I_CMPLX };
+    MCMtrx(controls, s, q1);
 
-    MCInvert(lControls.get(), controlLen + 1U, ONE_CMPLX, ONE_CMPLX, q2);
+    MCInvert(lControls, ONE_CMPLX, ONE_CMPLX, q2);
 
-    const complex had[4] = { C_SQRT1_2, C_SQRT1_2, C_SQRT1_2, -C_SQRT1_2 };
-    MCMtrx(lControls.get(), controlLen, had, q1);
+    const complex had[4]{ C_SQRT1_2, C_SQRT1_2, C_SQRT1_2, -C_SQRT1_2 };
+    MCMtrx(controls, had, q1);
 
-    const complex t[4] = { ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, C_SQRT_I };
-    MCMtrx(lControls.get(), controlLen, t, q1);
+    const complex t[4]{ ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, C_SQRT_I };
+    MCMtrx(controls, t, q1);
 
-    MCMtrx(lControls.get(), controlLen, had, q2);
+    MCMtrx(controls, had, q2);
 
-    MCMtrx(lControls.get(), controlLen, had, q1);
+    MCMtrx(controls, had, q1);
 
-    MCInvert(lControls.get(), controlLen + 1U, ONE_CMPLX, ONE_CMPLX, q2);
+    MCInvert(lControls, ONE_CMPLX, ONE_CMPLX, q2);
 
-    MCMtrx(lControls.get(), controlLen, had, q1);
+    MCMtrx(controls, had, q1);
 
-    MCMtrx(lControls.get(), controlLen, had, q2);
+    MCMtrx(controls, had, q2);
 
-    const complex it[4] = { ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, C_SQRT_N_I };
-    MCMtrx(lControls.get(), controlLen, it, q1);
+    const complex it[4]{ ONE_CMPLX, ZERO_CMPLX, ZERO_CMPLX, C_SQRT_N_I };
+    MCMtrx(controls, it, q1);
 
-    MCMtrx(lControls.get(), controlLen, t, q2);
+    MCMtrx(controls, t, q2);
 
-    MCMtrx(lControls.get(), controlLen, had, q1);
+    MCMtrx(controls, had, q1);
 
-    MCInvert(lControls.get(), controlLen + 1U, ONE_CMPLX, ONE_CMPLX, q2);
+    MCInvert(lControls, ONE_CMPLX, ONE_CMPLX, q2);
 }
 
-void QInterface::AntiCSqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt q1, bitLenInt q2)
+void QInterface::AntiCSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt q1, bitLenInt q2)
 {
     bitCapInt m = 0U;
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         m |= pow2(controls[i]);
     }
 
     XMask(m);
-    CSqrtSwap(controls, controlLen, q1, q2);
+    CSqrtSwap(controls, q1, q2);
     XMask(m);
 }
 
-void QInterface::AntiCISqrtSwap(bitLenInt const* controls, bitLenInt controlLen, bitLenInt q1, bitLenInt q2)
+void QInterface::AntiCISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt q1, bitLenInt q2)
 {
     bitCapInt m = 0U;
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         m |= pow2(controls[i]);
     }
 
     XMask(m);
-    CISqrtSwap(controls, controlLen, q1, q2);
+    CISqrtSwap(controls, q1, q2);
     XMask(m);
 }
 
@@ -754,7 +750,7 @@ void QInterface::TimeEvolve(Hamiltonian h, real1_f timeDiff_f)
             }
             UniformlyControlledSingleBit(op->controls.get(), op->controlLen, op->targetBit, expMtrx.get());
         } else {
-            complex timesI[4U] = { I_CMPLX * mtrx[0U], I_CMPLX * mtrx[1U], I_CMPLX * mtrx[2U], I_CMPLX * mtrx[3U] };
+            complex timesI[4U]{ I_CMPLX * mtrx[0U], I_CMPLX * mtrx[1U], I_CMPLX * mtrx[2U], I_CMPLX * mtrx[3U] };
             complex toApply[4U];
             exp2x2(timesI, toApply);
             if (op->controlLen == 0U) {

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -748,7 +748,7 @@ void QInterface::TimeEvolve(Hamiltonian h, real1_f timeDiff_f)
             for (bitCapIntOcl j = 0U; j < pow2(op->controls.size()); ++j) {
                 exp2x2(mtrx.get() + (j * 4U), expMtrx.get() + (j * 4U));
             }
-            UniformlyControlledSingleBit(&(op->controls[0]), op->controls.size(), op->targetBit, expMtrx.get());
+            UniformlyControlledSingleBit(op->controls, op->targetBit, expMtrx.get());
         } else {
             complex timesI[4U]{ I_CMPLX * mtrx[0U], I_CMPLX * mtrx[1U], I_CMPLX * mtrx[2U], I_CMPLX * mtrx[3U] };
             complex toApply[4U];
@@ -756,9 +756,9 @@ void QInterface::TimeEvolve(Hamiltonian h, real1_f timeDiff_f)
             if (op->controls.size() == 0U) {
                 Mtrx(toApply, op->targetBit);
             } else if (op->anti) {
-                MACMtrx(&(op->controls[0]), op->controls.size(), toApply, op->targetBit);
+                MACMtrx(op->controls, toApply, op->targetBit);
             } else {
-                MCMtrx(&(op->controls[0]), op->controls.size(), toApply, op->targetBit);
+                MCMtrx(op->controls, toApply, op->targetBit);
             }
         }
 

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -148,16 +148,16 @@ void QInterface::IQFT(bitLenInt start, bitLenInt length, bool trySeparate)
 }
 
 /// Quantum Fourier Transform - Optimized for going from |0>/|1> to |+>/|-> basis
-void QInterface::QFTR(bitLenInt const* qubits, bitLenInt length, bool trySeparate)
+void QInterface::QFTR(const std::vector<bitLenInt>& qubits, bool trySeparate)
 {
-    if (!length) {
+    if (!qubits.size()) {
         return;
     }
 
-    const bitLenInt end = (length - 1U);
-    for (bitLenInt i = 0U; i < length; ++i) {
+    const bitLenInt end = (qubits.size() - 1U);
+    for (bitLenInt i = 0U; i < qubits.size(); ++i) {
         H(qubits[end - i]);
-        for (bitLenInt j = 0U; j < (bitLenInt)((length - 1U) - i); ++j) {
+        for (bitLenInt j = 0U; j < (bitLenInt)((qubits.size() - 1U) - i); ++j) {
             CPhaseRootN(j + 2U, qubits[(end - i) - (j + 1U)], qubits[end - i]);
         }
 
@@ -168,13 +168,13 @@ void QInterface::QFTR(bitLenInt const* qubits, bitLenInt length, bool trySeparat
 }
 
 /// Inverse Quantum Fourier Transform - Quantum Fourier transform optimized for going from |+>/|-> to |0>/|1> basis
-void QInterface::IQFTR(bitLenInt const* qubits, bitLenInt length, bool trySeparate)
+void QInterface::IQFTR(const std::vector<bitLenInt>& qubits, bool trySeparate)
 {
-    if (!length) {
+    if (!qubits.size()) {
         return;
     }
 
-    for (bitLenInt i = 0U; i < length; ++i) {
+    for (bitLenInt i = 0U; i < qubits.size(); ++i) {
         for (bitLenInt j = 0U; j < i; ++j) {
             CIPhaseRootN(j + 2U, qubits[i - (j + 1U)], qubits[i]);
         }
@@ -221,27 +221,27 @@ bitCapInt QInterface::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt res
 }
 
 /// Bit-wise apply measurement gate to a register
-bitCapInt QInterface::ForceM(bitLenInt const* bits, bitLenInt length, bool const* values, bool doApply)
+bitCapInt QInterface::ForceM(const std::vector<bitLenInt>& bits, const std::vector<bool>& values, bool doApply)
 {
     bitCapInt result = 0U;
 
-    if (values) {
-        for (bitLenInt bit = 0U; bit < length; ++bit) {
+    if (values.size()) {
+        for (bitLenInt bit = 0U; bit < bits.size(); ++bit) {
             result |= ForceM(bits[bit], values[bit], true, doApply) ? pow2(bits[bit]) : 0U;
         }
         return result;
     }
 
     if (doApply) {
-        for (bitLenInt bit = 0U; bit < length; ++bit) {
+        for (bitLenInt bit = 0U; bit < bits.size(); ++bit) {
             result |= M(bits[bit]) ? pow2(bits[bit]) : 0U;
         }
         return result;
     }
 
-    std::unique_ptr<bitCapInt[]> qPowers(new bitCapInt[length]);
-    std::transform(bits, bits + length, qPowers.get(), pow2);
-    result = MultiShotMeasureMask(qPowers.get(), length, 1).begin()->first;
+    std::vector<bitCapInt> qPowers(bits.size());
+    std::transform(bits.begin(), bits.end(), qPowers.begin(), pow2);
+    result = MultiShotMeasureMask(qPowers, 1).begin()->first;
 
     return result;
 }
@@ -345,9 +345,9 @@ void QInterface::ProbMaskAll(bitCapInt mask, real1* probsArray)
     }
 }
 
-void QInterface::ProbBitsAll(bitLenInt const* bits, bitLenInt length, real1* probsArray)
+void QInterface::ProbBitsAll(const std::vector<bitLenInt>& bits, real1* probsArray)
 {
-    if (length == qubitCount) {
+    if (bits.size() == qubitCount) {
         bool isOrdered = true;
         for (bitLenInt i = 0U; i < qubitCount; ++i) {
             if (bits[i] != i) {
@@ -362,14 +362,14 @@ void QInterface::ProbBitsAll(bitLenInt const* bits, bitLenInt length, real1* pro
         }
     }
 
-    std::fill(probsArray, probsArray + pow2Ocl(length), ZERO_R1);
+    std::fill(probsArray, probsArray + pow2Ocl(bits.size()), ZERO_R1);
 
-    std::vector<bitCapInt> bitPowers(length);
-    std::transform(bits, bits + length, bitPowers.begin(), pow2);
+    std::vector<bitCapInt> bitPowers(bits.size());
+    std::transform(bits.begin(), bits.end(), bitPowers.begin(), pow2);
 
     for (bitCapInt lcv = 0U; lcv < maxQPower; ++lcv) {
         bitCapIntOcl retIndex = 0U;
-        for (bitLenInt p = 0U; p < length; ++p) {
+        for (bitLenInt p = 0U; p < bits.size(); ++p) {
             if (lcv & bitPowers[p]) {
                 retIndex |= pow2Ocl(p);
             }
@@ -378,22 +378,22 @@ void QInterface::ProbBitsAll(bitLenInt const* bits, bitLenInt length, real1* pro
     }
 }
 
-real1_f QInterface::ExpectationBitsAll(bitLenInt const* bits, bitLenInt length, bitCapInt offset)
+real1_f QInterface::ExpectationBitsAll(const std::vector<bitLenInt>& bits, bitCapInt offset)
 {
-    ThrowIfQbIdArrayIsBad(bits, length, qubitCount,
+    ThrowIfQbIdArrayIsBad(bits, qubitCount,
         "QInterface::ExpectationBitsAll parameter controls array values must be within allocated qubit bounds!");
 
-    if (length == 1U) {
+    if (bits.size() == 1U) {
         return Prob(bits[0]);
     }
 
-    std::vector<bitCapInt> bitPowers(length);
-    std::transform(bits, bits + length, bitPowers.begin(), pow2);
+    std::vector<bitCapInt> bitPowers(bits.size());
+    std::transform(bits.begin(), bits.end(), bitPowers.begin(), pow2);
 
     real1_f expectation = 0;
     for (bitCapInt lcv = 0U; lcv < maxQPower; ++lcv) {
         bitCapInt retIndex = 0U;
-        for (bitLenInt p = 0U; p < length; ++p) {
+        for (bitLenInt p = 0U; p < bits.size(); ++p) {
             if (lcv & bitPowers[p]) {
                 retIndex |= pow2(p);
             }
@@ -404,22 +404,21 @@ real1_f QInterface::ExpectationBitsAll(bitLenInt const* bits, bitLenInt length, 
     return expectation;
 }
 
-std::map<bitCapInt, int> QInterface::MultiShotMeasureMask(
-    bitCapInt const* qPowers, bitLenInt qPowerCount, unsigned shots)
+std::map<bitCapInt, int> QInterface::MultiShotMeasureMask(const std::vector<bitCapInt>& qPowers, unsigned shots)
 {
     if (!shots) {
         return std::map<bitCapInt, int>();
     }
 
-    std::unique_ptr<bitLenInt[]> bitMap(new bitLenInt[qPowerCount]);
-    std::transform(qPowers, qPowers + qPowerCount, bitMap.get(), log2);
+    std::vector<bitLenInt> bitMap(qPowers.size());
+    std::transform(qPowers.begin(), qPowers.end(), bitMap.begin(), log2);
 
-    ThrowIfQbIdArrayIsBad(bitMap.get(), qPowerCount, qubitCount,
+    ThrowIfQbIdArrayIsBad(bitMap, qubitCount,
         "QInterface::MultiShotMeasureMask parameter qPowers array values must be within allocated qubit bounds!");
 
-    const bitCapIntOcl maskMaxQPower = pow2Ocl(qPowerCount);
+    const bitCapIntOcl maskMaxQPower = pow2Ocl(qPowers.size());
     std::vector<real1> maskProbsVec((bitCapIntOcl)maskMaxQPower);
-    ProbBitsAll(bitMap.get(), qPowerCount, &(maskProbsVec[0]));
+    ProbBitsAll(bitMap, &(maskProbsVec[0]));
     std::discrete_distribution<bitCapIntOcl> dist(maskProbsVec.begin(), maskProbsVec.end());
 
     std::random_device rd;
@@ -434,21 +433,21 @@ std::map<bitCapInt, int> QInterface::MultiShotMeasureMask(
 }
 
 void QInterface::MultiShotMeasureMask(
-    bitCapInt const* qPowers, bitLenInt qPowerCount, unsigned shots, unsigned long long* shotsArray)
+    const std::vector<bitCapInt>& qPowers, unsigned shots, unsigned long long* shotsArray)
 {
     if (!shots) {
         return;
     }
 
-    std::unique_ptr<bitLenInt[]> bitMap(new bitLenInt[qPowerCount]);
-    std::transform(qPowers, qPowers + qPowerCount, bitMap.get(), log2);
+    std::vector<bitLenInt> bitMap(qPowers.size());
+    std::transform(qPowers.begin(), qPowers.end(), bitMap.begin(), log2);
 
-    ThrowIfQbIdArrayIsBad(bitMap.get(), qPowerCount, qubitCount,
+    ThrowIfQbIdArrayIsBad(bitMap, qubitCount,
         "QInterface::MultiShotMeasureMask parameter qPowers array values must be within allocated qubit bounds!");
 
-    const bitCapIntOcl maskMaxQPower = pow2Ocl(qPowerCount);
+    const bitCapIntOcl maskMaxQPower = pow2Ocl(qPowers.size());
     std::vector<real1> maskProbsVec((bitCapIntOcl)maskMaxQPower);
-    ProbBitsAll(bitMap.get(), qPowerCount, &(maskProbsVec[0]));
+    ProbBitsAll(bitMap, &(maskProbsVec[0]));
     std::discrete_distribution<bitCapIntOcl> dist(maskProbsVec.begin(), maskProbsVec.end());
 
     std::random_device rd;

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -221,11 +221,11 @@ bitCapInt QInterface::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt res
 }
 
 /// Bit-wise apply measurement gate to a register
-bitCapInt QInterface::ForceM(const std::vector<bitLenInt>& bits, const std::vector<bool>& values, bool doApply)
+bitCapInt QInterface::ForceM(const std::vector<bitLenInt>& bits, bool const* values, bool doApply)
 {
     bitCapInt result = 0U;
 
-    if (values.size()) {
+    if (values) {
         for (bitLenInt bit = 0U; bit < bits.size(); ++bit) {
             result |= ForceM(bits[bit], values[bit], true, doApply) ? pow2(bits[bit]) : 0U;
         }

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -221,11 +221,16 @@ bitCapInt QInterface::ForceMReg(bitLenInt start, bitLenInt length, bitCapInt res
 }
 
 /// Bit-wise apply measurement gate to a register
-bitCapInt QInterface::ForceM(const std::vector<bitLenInt>& bits, bool const* values, bool doApply)
+bitCapInt QInterface::ForceM(const std::vector<bitLenInt>& bits, const std::vector<bool>& values, bool doApply)
 {
+    if (values.size() && (bits.size() != values.size())) {
+        throw std::invalid_argument(
+            "QInterface::ForceM() boolean values vector length does not match bit vector length!");
+    }
+
     bitCapInt result = 0U;
 
-    if (values) {
+    if (values.size()) {
         for (bitLenInt bit = 0U; bit < bits.size(); ++bit) {
             result |= ForceM(bits[bit], values[bit], true, doApply) ? pow2(bits[bit]) : 0U;
         }

--- a/src/qinterface/rotational.cpp
+++ b/src/qinterface/rotational.cpp
@@ -27,26 +27,26 @@ void QInterface::U(bitLenInt target, real1_f theta, real1_f phi, real1_f lambda)
 
 /// Controlled general unitary gate
 void QInterface::CU(
-    bitLenInt const* controls, bitLenInt controlLen, bitLenInt target, real1_f theta, real1_f phi, real1_f lambda)
+    const std::vector<bitLenInt>& controls, bitLenInt target, real1_f theta, real1_f phi, real1_f lambda)
 {
     const real1 cos0 = (real1)cos(theta / 2);
     const real1 sin0 = (real1)sin(theta / 2);
     const complex uGate[4]{ complex(cos0, ZERO_R1), sin0 * complex((real1)(-cos(lambda)), (real1)(-sin(lambda))),
         sin0 * complex((real1)cos(phi), (real1)sin(phi)),
         cos0 * complex((real1)cos(phi + lambda), (real1)sin(phi + lambda)) };
-    MCMtrx(controls, controlLen, uGate, target);
+    MCMtrx(controls, uGate, target);
 }
 
 /// (Anti-)Controlled general unitary gate
 void QInterface::AntiCU(
-    bitLenInt const* controls, bitLenInt controlLen, bitLenInt target, real1_f theta, real1_f phi, real1_f lambda)
+    const std::vector<bitLenInt>& controls, bitLenInt target, real1_f theta, real1_f phi, real1_f lambda)
 {
     const real1 cos0 = (real1)cos(theta / 2);
     const real1 sin0 = (real1)sin(theta / 2);
     const complex uGate[4]{ complex(cos0, ZERO_R1), sin0 * complex((real1)(-cos(lambda)), (real1)(-sin(lambda))),
         sin0 * complex((real1)cos(phi), (real1)sin(phi)),
         cos0 * complex((real1)cos(phi + lambda), (real1)sin(phi + lambda)) };
-    MACMtrx(controls, controlLen, uGate, target);
+    MACMtrx(controls, uGate, target);
 }
 
 /// "Azimuth, Inclination"
@@ -81,8 +81,8 @@ void QInterface::CAI(bitLenInt control, bitLenInt target, real1_f azimuth, real1
     const real1 cosineI = (real1)cos(inclination / 2);
     const real1 sineI = (real1)sin(inclination / 2);
     const complex mtrx[4]{ cosineI, complex(-cosineA, sineA) * sineI, complex(cosineA, sineA) * sineI, cosineI };
-    const bitLenInt controls[1]{ control };
-    MCMtrx(controls, 1U, mtrx, target);
+    const std::vector<bitLenInt> controls{ control };
+    MCMtrx(controls, mtrx, target);
 }
 
 /// Controlled inverse "Azimuth, Inclination"
@@ -93,10 +93,10 @@ void QInterface::CIAI(bitLenInt control, bitLenInt target, real1_f azimuth, real
     const real1 cosineI = (real1)cos(inclination / 2);
     const real1 sineI = (real1)sin(inclination / 2);
     const complex mtrx[4]{ cosineI, complex(-cosineA, sineA) * sineI, complex(cosineA, sineA) * sineI, cosineI };
-    const bitLenInt controls[1]{ control };
+    const std::vector<bitLenInt> controls{ control };
     complex invMtrx[4];
     inv2x2(mtrx, invMtrx);
-    MCMtrx(controls, 1U, invMtrx, target);
+    MCMtrx(controls, invMtrx, target);
 }
 
 /// Controlled "Azimuth, Inclination"
@@ -107,8 +107,8 @@ void QInterface::AntiCAI(bitLenInt control, bitLenInt target, real1_f azimuth, r
     const real1 cosineI = (real1)cos(inclination / 2);
     const real1 sineI = (real1)sin(inclination / 2);
     const complex mtrx[4]{ cosineI, complex(-cosineA, sineA) * sineI, complex(cosineA, sineA) * sineI, cosineI };
-    const bitLenInt controls[1]{ control };
-    MACMtrx(controls, 1U, mtrx, target);
+    const std::vector<bitLenInt> controls{ control };
+    MACMtrx(controls, mtrx, target);
 }
 
 /// Controlled inverse "Azimuth, Inclination"
@@ -119,18 +119,18 @@ void QInterface::AntiCIAI(bitLenInt control, bitLenInt target, real1_f azimuth, 
     const real1 cosineI = (real1)cos(inclination / 2);
     const real1 sineI = (real1)sin(inclination / 2);
     const complex mtrx[4]{ cosineI, complex(-cosineA, sineA) * sineI, complex(cosineA, sineA) * sineI, cosineI };
-    const bitLenInt controls[1]{ control };
+    const std::vector<bitLenInt> controls{ control };
     complex invMtrx[4];
     inv2x2(mtrx, invMtrx);
-    MACMtrx(controls, 1U, invMtrx, target);
+    MACMtrx(controls, invMtrx, target);
 }
 
 /// Uniformly controlled y axis rotation gate - Rotates as e^(-i*\theta_k/2) around Pauli y axis for each permutation
 /// "k" of the control bits.
 void QInterface::UniformlyControlledRY(
-    bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubitIndex, real1 const* angles)
+    const std::vector<bitLenInt>& controls, bitLenInt qubitIndex, real1 const* angles)
 {
-    const bitCapIntOcl permCount = pow2Ocl(controlLen);
+    const bitCapIntOcl permCount = pow2Ocl(controls.size());
     std::unique_ptr<complex[]> pauliRYs(new complex[4U * permCount]);
 
     for (bitCapIntOcl i = 0U; i < permCount; ++i) {
@@ -143,15 +143,15 @@ void QInterface::UniformlyControlledRY(
         pauliRYs[3U + 4U * i] = complex(cosine, ZERO_R1);
     }
 
-    UniformlyControlledSingleBit(controls, controlLen, qubitIndex, pauliRYs.get());
+    UniformlyControlledSingleBit(controls, qubitIndex, pauliRYs.get());
 }
 
 /// Uniformly controlled z axis rotation gate - Rotates as e^(-i*\theta_k/2) around Pauli z axis for each permutation
 /// "k" of the control bits.
 void QInterface::UniformlyControlledRZ(
-    bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubitIndex, real1 const* angles)
+    const std::vector<bitLenInt>& controls, bitLenInt qubitIndex, real1 const* angles)
 {
-    const bitCapIntOcl permCount = pow2Ocl(controlLen);
+    const bitCapIntOcl permCount = pow2Ocl(controls.size());
     std::unique_ptr<complex[]> pauliRZs(new complex[4U * permCount]);
 
     for (bitCapIntOcl i = 0U; i < permCount; ++i) {
@@ -164,7 +164,7 @@ void QInterface::UniformlyControlledRZ(
         pauliRZs[3U + 4U * i] = complex(cosine, sine);
     }
 
-    UniformlyControlledSingleBit(controls, controlLen, qubitIndex, pauliRZs.get());
+    UniformlyControlledSingleBit(controls, qubitIndex, pauliRZs.get());
 }
 
 /// "Phase shift gate" - Rotates as e^(-i*\theta/2) around |1> state
@@ -205,8 +205,8 @@ void QInterface::CRZ(real1_f radians, bitLenInt control, bitLenInt target)
 {
     const real1 cosine = (real1)cos(radians / 2);
     const real1 sine = (real1)sin(radians / 2);
-    const bitLenInt controls[1]{ control };
-    MCPhase(controls, 1, complex(cosine, -sine), complex(cosine, sine), target);
+    const std::vector<bitLenInt> controls{ control };
+    MCPhase(controls, complex(cosine, -sine), complex(cosine, sine), target);
 }
 
 /// Controlled y axis rotation - if control bit is true, rotates as e^(-i*\theta) around Pauli y axis
@@ -216,8 +216,8 @@ void QInterface::CRY(real1_f radians, bitLenInt control, bitLenInt target)
     const real1 sine = (real1)sin(radians / 2);
     const complex pauliRY[4]{ complex(cosine, ZERO_R1), complex(-sine, ZERO_R1), complex(sine, ZERO_R1),
         complex(cosine, ZERO_R1) };
-    const bitLenInt controls[1]{ control };
-    MCMtrx(controls, 1, pauliRY, target);
+    const std::vector<bitLenInt> controls{ control };
+    MCMtrx(controls, pauliRY, target);
 }
 
 #if ENABLE_ROT_API
@@ -229,8 +229,7 @@ void QInterface::Exp(real1_f radians, bitLenInt qubit)
 }
 
 /// Imaginary exponentiate of arbitrary single bit gate
-void QInterface::Exp(
-    bitLenInt const* controls, bitLenInt controlLen, bitLenInt qubit, complex const* matrix2x2, bool antiCtrled)
+void QInterface::Exp(const std::vector<bitLenInt>& controls, bitLenInt qubit, complex const* matrix2x2, bool antiCtrled)
 {
     complex timesI[4U];
     for (bitLenInt i = 0U; i < 4U; ++i) {
@@ -239,9 +238,9 @@ void QInterface::Exp(
     complex toApply[4U];
     exp2x2(timesI, toApply);
     if (antiCtrled) {
-        MACMtrx(controls, controlLen, toApply, qubit);
+        MACMtrx(controls, toApply, qubit);
     } else {
-        MCMtrx(controls, controlLen, toApply, qubit);
+        MCMtrx(controls, toApply, qubit);
     }
 }
 

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -560,10 +560,9 @@ template <typename F> void QPager::CombineAndOp(F fn, std::vector<bitLenInt> bit
 }
 
 template <typename F>
-void QPager::CombineAndOpControlled(
-    F fn, std::vector<bitLenInt> bits, bitLenInt const* controls, const bitLenInt controlLen)
+void QPager::CombineAndOpControlled(F fn, std::vector<bitLenInt> bits, const std::vector<bitLenInt>& controls)
 {
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         bits.push_back(controls[i]);
     }
 
@@ -922,9 +921,9 @@ void QPager::ApplySingleEither(bool isInvert, complex top, complex bottom, bitLe
 }
 
 void QPager::ApplyEitherControlledSingleBit(
-    bool anti, bitLenInt const* controls, bitLenInt controlLen, bitLenInt target, complex const* mtrx)
+    bool anti, const std::vector<bitLenInt>& controls, bitLenInt target, complex const* mtrx)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         Mtrx(mtrx, target);
         return;
     }
@@ -936,7 +935,7 @@ void QPager::ApplyEitherControlledSingleBit(
     std::vector<bitLenInt> metaControls;
     std::vector<bitLenInt> intraControls;
     bool isSqiCtrl = false;
-    for (bitLenInt i = 0U; i < controlLen; ++i) {
+    for (bitLenInt i = 0U; i < controls.size(); ++i) {
         if ((target >= qpp) && (controls[i] == (qpp - 1U))) {
             isSqiCtrl = true;
         } else if (controls[i] < qpp) {
@@ -972,10 +971,10 @@ void QPager::UniformParityRZ(bitCapInt mask, real1_f angle)
     CombineAndOp([&](QEnginePtr engine) { engine->UniformParityRZ(mask, angle); }, { log2(mask) });
 }
 
-void QPager::CUniformParityRZ(bitLenInt const* controls, bitLenInt controlLen, bitCapInt mask, real1_f angle)
+void QPager::CUniformParityRZ(const std::vector<bitLenInt>& controls, bitCapInt mask, real1_f angle)
 {
-    CombineAndOpControlled([&](QEnginePtr engine) { engine->CUniformParityRZ(controls, controlLen, mask, angle); },
-        { log2(mask) }, controls, controlLen);
+    CombineAndOpControlled(
+        [&](QEnginePtr engine) { engine->CUniformParityRZ(controls, mask, angle); }, { log2(mask) }, controls);
 }
 
 void QPager::XMask(bitCapInt mask)
@@ -1129,33 +1128,31 @@ void QPager::POWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLe
         { static_cast<bitLenInt>(inStart + length - 1U), static_cast<bitLenInt>(outStart + length - 1U) });
 }
 void QPager::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
-    bitLenInt const* controls, bitLenInt controlLen)
+    const std::vector<bitLenInt>& controls)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         MUL(toMul, inOutStart, carryStart, length);
         return;
     }
 
-    CombineAndOpControlled(
-        [&](QEnginePtr engine) { engine->CMUL(toMul, inOutStart, carryStart, length, controls, controlLen); },
+    CombineAndOpControlled([&](QEnginePtr engine) { engine->CMUL(toMul, inOutStart, carryStart, length, controls); },
         { static_cast<bitLenInt>(inOutStart + length - 1U), static_cast<bitLenInt>(carryStart + length - 1U) },
-        controls, controlLen);
+        controls);
 }
 void QPager::CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
-    bitLenInt const* controls, bitLenInt controlLen)
+    const std::vector<bitLenInt>& controls, bitLenInt controlLen)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         DIV(toDiv, inOutStart, carryStart, length);
         return;
     }
 
-    CombineAndOpControlled(
-        [&](QEnginePtr engine) { engine->CDIV(toDiv, inOutStart, carryStart, length, controls, controlLen); },
+    CombineAndOpControlled([&](QEnginePtr engine) { engine->CDIV(toDiv, inOutStart, carryStart, length, controls); },
         { static_cast<bitLenInt>(inOutStart + length - 1U), static_cast<bitLenInt>(carryStart + length - 1U) },
-        controls, controlLen);
+        controls);
 }
 void QPager::CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-    bitLenInt const* controls, bitLenInt controlLen)
+    const std::vector<bitLenInt>& controls)
 {
     if (!controlLen) {
         MULModNOut(toMul, modN, inStart, outStart, length);
@@ -1163,25 +1160,23 @@ void QPager::CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bit
     }
 
     CombineAndOpControlled(
-        [&](QEnginePtr engine) { engine->CMULModNOut(toMul, modN, inStart, outStart, length, controls, controlLen); },
-        { static_cast<bitLenInt>(inStart + length - 1U), static_cast<bitLenInt>(outStart + length - 1U) }, controls,
-        controlLen);
+        [&](QEnginePtr engine) { engine->CMULModNOut(toMul, modN, inStart, outStart, length, controls); },
+        { static_cast<bitLenInt>(inStart + length - 1U), static_cast<bitLenInt>(outStart + length - 1U) }, controls);
 }
 void QPager::CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-    bitLenInt const* controls, bitLenInt controlLen)
+    const std::vector<bitLenInt>& controls)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         IMULModNOut(toMul, modN, inStart, outStart, length);
         return;
     }
 
     CombineAndOpControlled(
-        [&](QEnginePtr engine) { engine->CIMULModNOut(toMul, modN, inStart, outStart, length, controls, controlLen); },
-        { static_cast<bitLenInt>(inStart + length - 1U), static_cast<bitLenInt>(outStart + length - 1U) }, controls,
-        controlLen);
+        [&](QEnginePtr engine) { engine->CIMULModNOut(toMul, modN, inStart, outStart, length, controls); },
+        { static_cast<bitLenInt>(inStart + length - 1U), static_cast<bitLenInt>(outStart + length - 1U) }, controls);
 }
 void QPager::CPOWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-    bitLenInt const* controls, bitLenInt controlLen)
+    const std::vector<bitLenInt>& controls)
 {
     if (!controlLen) {
         POWModNOut(base, modN, inStart, outStart, length);
@@ -1189,9 +1184,8 @@ void QPager::CPOWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitL
     }
 
     CombineAndOpControlled(
-        [&](QEnginePtr engine) { engine->CPOWModNOut(base, modN, inStart, outStart, length, controls, controlLen); },
-        { static_cast<bitLenInt>(inStart + length - 1U), static_cast<bitLenInt>(outStart + length - 1U) }, controls,
-        controlLen);
+        [&](QEnginePtr engine) { engine->CPOWModNOut(base, modN, inStart, outStart, length, controls); },
+        { static_cast<bitLenInt>(inStart + length - 1U), static_cast<bitLenInt>(outStart + length - 1U) }, controls);
 }
 
 bitCapInt QPager::IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
@@ -1426,15 +1420,15 @@ real1_f QPager::ProbMask(bitCapInt mask, bitCapInt permutation)
     return clampProb((real1_f)maskChance);
 }
 
-real1_f QPager::ExpectationBitsAll(bitLenInt const* bits, bitLenInt length, bitCapInt offset)
+real1_f QPager::ExpectationBitsAll(const std::vector<bitLenInt>& bits, bitCapInt offset)
 {
-    if (length != qubitCount) {
-        return QInterface::ExpectationBitsAll(bits, length, offset);
+    if (bits.size() != qubitCount) {
+        return QInterface::ExpectationBitsAll(bits, offset);
     }
 
-    for (bitCapIntOcl i = 0U; i < length; ++i) {
+    for (bitCapIntOcl i = 0U; i < bits.size(); ++i) {
         if (bits[i] != i) {
-            return QInterface::ExpectationBitsAll(bits, length, offset);
+            return QInterface::ExpectationBitsAll(bits, offset);
         }
     }
 

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -948,9 +948,9 @@ void QPager::ApplyEitherControlledSingleBit(
     auto sg = [anti, mtrx, intraControls](QEnginePtr engine, bitLenInt lTarget) {
         if (intraControls.size()) {
             if (anti) {
-                engine->MACMtrx(&(intraControls[0U]), intraControls.size(), mtrx, lTarget);
+                engine->MACMtrx(intraControls, mtrx, lTarget);
             } else {
-                engine->MCMtrx(&(intraControls[0U]), intraControls.size(), mtrx, lTarget);
+                engine->MCMtrx(intraControls, mtrx, lTarget);
             }
         } else {
             engine->Mtrx(mtrx, lTarget);
@@ -1140,7 +1140,7 @@ void QPager::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, b
         controls);
 }
 void QPager::CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
-    const std::vector<bitLenInt>& controls, bitLenInt controlLen)
+    const std::vector<bitLenInt>& controls)
 {
     if (!controls.size()) {
         DIV(toDiv, inOutStart, carryStart, length);
@@ -1154,7 +1154,7 @@ void QPager::CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, b
 void QPager::CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
     const std::vector<bitLenInt>& controls)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         MULModNOut(toMul, modN, inStart, outStart, length);
         return;
     }
@@ -1178,7 +1178,7 @@ void QPager::CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bi
 void QPager::CPOWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
     const std::vector<bitLenInt>& controls)
 {
-    if (!controlLen) {
+    if (!controls.size()) {
         POWModNOut(base, modN, inStart, outStart, length);
         return;
     }
@@ -1442,11 +1442,10 @@ real1_f QPager::ExpectationBitsAll(const std::vector<bitLenInt>& bits, bitCapInt
     for (bitCapIntOcl i = 0U; i < qPages.size(); ++i) {
         QEnginePtr engine = qPages[i];
 #if ENABLE_PTHREAD
-        futures[i] = std::async(std::launch::async, [engine, bits, qpp, pagePerm, offset]() {
-            return engine->ExpectationBitsAll(bits, qpp, pagePerm + offset);
-        });
+        futures[i] = std::async(std::launch::async,
+            [engine, bits, qpp, pagePerm, offset]() { return engine->ExpectationBitsAll(bits, pagePerm + offset); });
 #else
-        expectation += engine->ExpectationBitsAll(bits, qpp, pagePerm + offset);
+        expectation += engine->ExpectationBitsAll(bits, pagePerm + offset);
 #endif
         pagePerm += pagePower;
     }

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -1710,17 +1710,17 @@ void QStabilizer::MACInvert(
 
 void QStabilizer::FSim(real1_f theta, real1_f phi, bitLenInt qubit1, bitLenInt qubit2)
 {
-    const bitLenInt controls[1U]{ qubit1 };
+    const std::vector<bitLenInt> controls{ qubit1 };
     real1 sinTheta = (real1)sin(theta);
 
     if (IS_0_R1(sinTheta)) {
-        MCPhase(controls, 1U, ONE_CMPLX, exp(complex(ZERO_R1, (real1)phi)), qubit2);
+        MCPhase(controls, ONE_CMPLX, exp(complex(ZERO_R1, (real1)phi)), qubit2);
         return;
     }
 
     if (IS_1_R1(-sinTheta)) {
         ISwap(qubit1, qubit2);
-        MCPhase(controls, 1U, ONE_CMPLX, exp(complex(ZERO_R1, (real1)phi)), qubit2);
+        MCPhase(controls, ONE_CMPLX, exp(complex(ZERO_R1, (real1)phi)), qubit2);
         return;
     }
 
@@ -1729,13 +1729,13 @@ void QStabilizer::FSim(real1_f theta, real1_f phi, bitLenInt qubit1, bitLenInt q
 
 bool QStabilizer::TrySeparate(const std::vector<bitLenInt>& qubits, real1_f ignored)
 {
-    for (bitLenInt i = 0U; i < length; ++i) {
+    for (bitLenInt i = 0U; i < qubits.size(); ++i) {
         Swap(qubits[i], i);
     }
 
     const bool toRet = CanDecomposeDispose(0U, 2U);
 
-    for (bitLenInt i = 0U; i < length; ++i) {
+    for (bitLenInt i = 0U; i < qubits.size(); ++i) {
         Swap(qubits[i], i);
     }
 

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -58,10 +58,9 @@ QStabilizer::QStabilizer(bitLenInt n, bitCapInt perm, qrack_rand_gen_ptr rgp, co
     SetPermutation(perm);
 }
 
-bool QStabilizer::TrimControls(
-    const bitLenInt* lControls, bitLenInt lControlLen, bool isAnti, std::vector<bitLenInt>& output)
+bool QStabilizer::TrimControls(const std::vector<bitLenInt>& lControls, bool isAnti, std::vector<bitLenInt>& output)
 {
-    for (bitLenInt i = 0U; i < lControlLen; ++i) {
+    for (bitLenInt i = 0U; i < lControls.size(); ++i) {
         const bitLenInt bit = lControls[i];
         if (!IsSeparableZ(bit)) {
             output.push_back(bit);
@@ -1414,14 +1413,14 @@ void QStabilizer::Invert(complex topRight, complex bottomLeft, bitLenInt target)
 }
 
 void QStabilizer::MCPhase(
-    const bitLenInt* lControls, bitLenInt lControlLen, complex topLeft, complex bottomRight, bitLenInt target)
+    const std::vector<bitLenInt>& lControls, complex topLeft, complex bottomRight, bitLenInt target)
 {
     if (IS_NORM_0(topLeft - ONE_CMPLX) && IS_NORM_0(bottomRight - ONE_CMPLX)) {
         return;
     }
 
     std::vector<bitLenInt> controls;
-    if (TrimControls(lControls, lControlLen, false, controls)) {
+    if (TrimControls(lControls, false, controls)) {
         return;
     }
 
@@ -1496,14 +1495,14 @@ void QStabilizer::MCPhase(
 }
 
 void QStabilizer::MACPhase(
-    const bitLenInt* lControls, bitLenInt lControlLen, complex topLeft, complex bottomRight, bitLenInt target)
+    const std::vector<bitLenInt>& lControls, complex topLeft, complex bottomRight, bitLenInt target)
 {
     if (IS_NORM_0(topLeft - ONE_CMPLX) && IS_NORM_0(bottomRight - ONE_CMPLX)) {
         return;
     }
 
     std::vector<bitLenInt> controls;
-    if (TrimControls(lControls, lControlLen, true, controls)) {
+    if (TrimControls(lControls, true, controls)) {
         return;
     }
 
@@ -1578,10 +1577,10 @@ void QStabilizer::MACPhase(
 }
 
 void QStabilizer::MCInvert(
-    const bitLenInt* lControls, bitLenInt lControlLen, complex topRight, complex bottomLeft, bitLenInt target)
+    const std::vector<bitLenInt>& lControls, complex topRight, complex bottomLeft, bitLenInt target)
 {
     std::vector<bitLenInt> controls;
-    if (TrimControls(lControls, lControlLen, false, controls)) {
+    if (TrimControls(lControls, false, controls)) {
         return;
     }
 
@@ -1644,10 +1643,10 @@ void QStabilizer::MCInvert(
 }
 
 void QStabilizer::MACInvert(
-    const bitLenInt* lControls, bitLenInt lControlLen, complex topRight, complex bottomLeft, bitLenInt target)
+    const std::vector<bitLenInt>& lControls, complex topRight, complex bottomLeft, bitLenInt target)
 {
     std::vector<bitLenInt> controls;
-    if (TrimControls(lControls, lControlLen, true, controls)) {
+    if (TrimControls(lControls, true, controls)) {
         return;
     }
 
@@ -1728,7 +1727,7 @@ void QStabilizer::FSim(real1_f theta, real1_f phi, bitLenInt qubit1, bitLenInt q
     throw std::domain_error("QStabilizer::FSim() not implemented for non-Clifford/Pauli cases!");
 }
 
-bool QStabilizer::TrySeparate(const bitLenInt* qubits, bitLenInt length, real1_f ignored)
+bool QStabilizer::TrySeparate(const std::vector<bitLenInt>& qubits, real1_f ignored)
 {
     for (bitLenInt i = 0U; i < length; ++i) {
         Swap(qubits[i], i);

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -1184,7 +1184,7 @@ real1_f QStabilizer::Prob(bitLenInt qubit)
     return ONE_R1_F / 2;
 }
 
-void QStabilizer::Mtrx(const complex* mtrx, bitLenInt target)
+void QStabilizer::Mtrx(complex const* mtrx, bitLenInt target)
 {
     if (IS_NORM_0(mtrx[1U]) && IS_NORM_0(mtrx[2U])) {
         Phase(mtrx[0U], mtrx[3U], target);

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -576,7 +576,7 @@ complex QStabilizerHybrid::GetAmplitude(bitCapInt perm)
     return clone->GetAmplitude(perm);
 }
 
-void QStabilizerHybrid::SetQuantumState(const complex* inputState)
+void QStabilizerHybrid::SetQuantumState(complex const* inputState)
 {
     DumpBuffers();
 
@@ -610,7 +610,7 @@ void QStabilizerHybrid::SetQuantumState(const complex* inputState)
     Mtrx(mtrx, 0);
 }
 
-void QStabilizerHybrid::Mtrx(const complex* lMtrx, bitLenInt target)
+void QStabilizerHybrid::Mtrx(complex const* lMtrx, bitLenInt target)
 {
     const bool wasCached = (bool)shards[target];
     complex mtrx[4U];
@@ -638,7 +638,7 @@ void QStabilizerHybrid::Mtrx(const complex* lMtrx, bitLenInt target)
     }
 }
 
-void QStabilizerHybrid::MCMtrx(const std::vector<bitLenInt>& lControls, const complex* mtrx, bitLenInt target)
+void QStabilizerHybrid::MCMtrx(const std::vector<bitLenInt>& lControls, complex const* mtrx, bitLenInt target)
 {
     if (IS_NORM_0(mtrx[1U]) && IS_NORM_0(mtrx[2U])) {
         MCPhase(lControls, mtrx[0U], mtrx[3U], target);
@@ -755,7 +755,7 @@ void QStabilizerHybrid::MCInvert(
     }
 }
 
-void QStabilizerHybrid::MACMtrx(const std::vector<bitLenInt>& lControls, const complex* mtrx, bitLenInt target)
+void QStabilizerHybrid::MACMtrx(const std::vector<bitLenInt>& lControls, complex const* mtrx, bitLenInt target)
 {
     if (IS_NORM_0(mtrx[1U]) && IS_NORM_0(mtrx[2U])) {
         MACPhase(lControls, mtrx[0U], mtrx[3U], target);

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -114,7 +114,7 @@ void QUnit::SetPermutation(bitCapInt perm, complex phaseFac)
     }
 }
 
-void QUnit::SetQuantumState(const complex* inputState)
+void QUnit::SetQuantumState(complex const* inputState)
 {
     Dump();
 
@@ -1962,7 +1962,7 @@ void QUnit::FSim(real1_f theta, real1_f phi, bitLenInt qubit1, bitLenInt qubit2)
 }
 
 void QUnit::UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls, bitLenInt qubitIndex,
-    const complex* mtrxs, const std::vector<bitCapInt>& mtrxSkipPowers, bitCapInt mtrxSkipValueMask)
+    complex const* mtrxs, const std::vector<bitCapInt>& mtrxSkipPowers, bitCapInt mtrxSkipValueMask)
 {
     // If there are no controls, this is equivalent to the single bit gate.
     if (!controls.size()) {
@@ -2139,7 +2139,7 @@ void QUnit::ZBase(bitLenInt target)
     shard.amp1 = -shard.amp1;
 }
 
-void QUnit::TransformX2x2(const complex* mtrxIn, complex* mtrxOut)
+void QUnit::TransformX2x2(complex const* mtrxIn, complex* mtrxOut)
 {
     mtrxOut[0U] = (real1)(ONE_R1 / 2) * (complex)(mtrxIn[0U] + mtrxIn[1U] + mtrxIn[2U] + mtrxIn[3U]);
     mtrxOut[1U] = (real1)(ONE_R1 / 2) * (complex)(mtrxIn[0U] - mtrxIn[1U] + mtrxIn[2U] - mtrxIn[3U]);
@@ -2155,7 +2155,7 @@ void QUnit::TransformXInvert(complex topRight, complex bottomLeft, complex* mtrx
     mtrxOut[3U] = -mtrxOut[0U];
 }
 
-void QUnit::TransformY2x2(const complex* mtrxIn, complex* mtrxOut)
+void QUnit::TransformY2x2(complex const* mtrxIn, complex* mtrxOut)
 {
     mtrxOut[0U] = (real1)(ONE_R1 / 2) * (complex)(mtrxIn[0U] + I_CMPLX * (mtrxIn[1U] - mtrxIn[2U]) + mtrxIn[3U]);
     mtrxOut[1U] = (real1)(ONE_R1 / 2) * (complex)(mtrxIn[0U] - I_CMPLX * (mtrxIn[1U] + mtrxIn[2U]) - mtrxIn[3U]);
@@ -2553,7 +2553,7 @@ void QUnit::MACInvert(const std::vector<bitLenInt>& lControls, complex topRight,
     CTRLED_PHASE_INVERT_WRAP(MACInvert(CTRL_I_ARGS), MACMtrx(CTRL_GEN_ARGS), true, topRight, bottomLeft);
 }
 
-void QUnit::Mtrx(const complex* mtrx, bitLenInt target)
+void QUnit::Mtrx(complex const* mtrx, bitLenInt target)
 {
     QEngineShard& shard = shards[target];
 
@@ -2612,7 +2612,7 @@ void QUnit::Mtrx(const complex* mtrx, bitLenInt target)
     ClampShard(target);
 }
 
-void QUnit::MCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
+void QUnit::MCMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target)
 {
     if (IS_NORM_0(mtrx[1U]) && IS_NORM_0(mtrx[2U])) {
         MCPhase(controls, mtrx[0U], mtrx[3U], target);
@@ -2644,7 +2644,7 @@ void QUnit::MCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, 
     CTRLED_GEN_WRAP(MCMtrx(CTRL_GEN_ARGS));
 }
 
-void QUnit::MACMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
+void QUnit::MACMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target)
 {
     if (IS_NORM_0(mtrx[1U]) && IS_NORM_0(mtrx[2U])) {
         MACPhase(controls, mtrx[0U], mtrx[3U], target);

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -1707,8 +1707,8 @@ TEST_CASE("test_stabilizer_t_cc_nn", "[supreme]")
 
                     if (is3Qubit) {
                         if ((gateRand < (3 * ONE_R1)) && ((8 * qReg->Rand()) < ONE_R1)) {
-                            const bitLenInt controls[1U] = { b1 };
-                            qReg->CSwap(controls, 1U, b2, b3);
+                            const std::vector<bitLenInt> controls{ b1 };
+                            qReg->CSwap(controls, b2, b3);
                             continue;
                         }
 
@@ -1993,8 +1993,8 @@ TEST_CASE("test_noisy_stabilizer_t_cc_nn", "[supreme]")
                         }
 
                         if ((gateRand < (3 * ONE_R1)) && ((8 * qReg->Rand()) < ONE_R1)) {
-                            const bitLenInt controls[1U] = { b1 };
-                            qReg->CSwap(controls, 1U, b2, b3);
+                            const std::vector<bitLenInt> controls{ b1 };
+                            qReg->CSwap(controls, b2, b3);
                             continue;
                         }
 
@@ -2211,8 +2211,8 @@ TEST_CASE("test_dense_cc_nn", "[supreme]")
 
                     if (is3Qubit) {
                         if ((8 * qReg->Rand()) < ONE_R1) {
-                            const bitLenInt controls[1U] = { b1 };
-                            qReg->CSwap(controls, 1U, b2, b3);
+                            const std::vector<bitLenInt> controls{ b1 };
+                            qReg->CSwap(controls, b2, b3);
                             continue;
                         }
 
@@ -2430,8 +2430,8 @@ TEST_CASE("test_noisy_dense_cc_nn", "[supreme]")
                         inject_1qb_u3_noise(qReg, b3, noiseParam);
 
                         if ((8 * qReg->Rand()) < ONE_R1) {
-                            const bitLenInt controls[1U] = { b1 };
-                            qReg->CSwap(controls, 1U, b2, b3);
+                            const std::vector<bitLenInt> controls{ b1 };
+                            qReg->CSwap(controls, b2, b3);
                             continue;
                         }
 
@@ -2537,7 +2537,7 @@ TEST_CASE("test_stabilizer_ct_nn", "[supreme]")
         bitLenInt b1, b2;
         int row, col;
         int tempRow, tempCol;
-        bitLenInt controls[1];
+        std::vector<bitLenInt> controls;
 
         // The test runs 2 bit gates according to a tiling sequence.
         // The 1 bit indicates +/- column offset.
@@ -2702,7 +2702,7 @@ TEST_CASE("test_stabilizer_ct_nn", "[supreme]")
                             controls[0] = b1;
                             top = std::polar(ONE_R1, (real1)(2 * PI_R1 * qReg->Rand()));
                             bottom = std::conj(top);
-                            qReg->MCPhase(controls, 1U, top, bottom, b2);
+                            qReg->MCPhase(controls, top, bottom, b2);
                         } else {
                             // "Phase" transforms:
                             gateRand = DimCountMultiQb * qReg->Rand();
@@ -2733,7 +2733,7 @@ TEST_CASE("test_stabilizer_ct_nn", "[supreme]")
                             controls[0] = b1;
                             top = std::polar(ONE_R1, (real1)(2 * PI_R1 * qReg->Rand()));
                             bottom = std::conj(top);
-                            qReg->MACPhase(controls, 1U, top, bottom, b2);
+                            qReg->MACPhase(controls, top, bottom, b2);
                         }
                     }
                 }
@@ -2933,7 +2933,7 @@ TEST_CASE("test_universal_circuit_analog", "[supreme]")
             bitLenInt i;
             real1_f gateRand;
             bitLenInt b1, b2, b3;
-            bitLenInt control[1];
+            std::vector<bitLenInt> control;
             complex polar0;
             bool canDo3;
             int gateThreshold, gateMax;
@@ -2983,9 +2983,9 @@ TEST_CASE("test_universal_circuit_analog", "[supreme]")
                         control[0] = b1;
                         polar0 = complex(std::polar(ONE_R1, (real1)(2 * M_PI * qReg->Rand())));
                         if (gateRand < (gateThreshold * ONE_R1 / gateMax)) {
-                            qReg->MCPhase(control, 1U, polar0, -polar0, b2);
+                            qReg->MCPhase(control, polar0, -polar0, b2);
                         } else {
-                            qReg->MCInvert(control, 1U, polar0, polar0, b2);
+                            qReg->MCInvert(control, polar0, polar0, b2);
                         }
                     }
                 }
@@ -3110,7 +3110,7 @@ TEST_CASE("test_quantum_supremacy", "[supreme]")
         int row, col;
         int tempRow, tempCol;
 
-        bitLenInt controls[1];
+        std::vector<bitLenInt> controls;
 
         std::vector<int> lastSingleBitGates;
         std::set<int>::iterator gateChoiceIterator;
@@ -3222,7 +3222,7 @@ TEST_CASE("test_quantum_supremacy", "[supreme]")
                     qReg->ISwap(b1, b2);
                     // "1/6 of CZ" is read to indicate the 6th root.
                     controls[0] = b1;
-                    qReg->MCPhase(controls, 1U, ONE_CMPLX, sixthRoot, b2);
+                    qReg->MCPhase(controls, ONE_CMPLX, sixthRoot, b2);
                     // Note that these gates are both symmetric under exchange of "b1" and "b2".
 
                     // std::cout<<"("<<b1<<", "<<b2<<")"<<std::endl;
@@ -3284,7 +3284,7 @@ TEST_CASE("test_noisy_sycamore", "[supreme]")
         int row, col;
         int tempRow, tempCol;
 
-        bitLenInt controls[1];
+        std::vector<bitLenInt> controls;
 
         std::vector<int> lastSingleBitGates;
         std::set<int>::iterator gateChoiceIterator;
@@ -3399,7 +3399,7 @@ TEST_CASE("test_noisy_sycamore", "[supreme]")
                     // complex sixthRoot = pow(-ONE_CMPLX, complex(root));
 
                     controls[0] = b1;
-                    qReg->MCPhase(controls, 1U, ONE_CMPLX, sixthRoot, b2);
+                    qReg->MCPhase(controls, ONE_CMPLX, sixthRoot, b2);
                     // Note that these gates are both symmetric under exchange of "b1" and "b2".
 
                     // std::cout<<"("<<b1<<", "<<b2<<")"<<std::endl;
@@ -3678,12 +3678,12 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
         }
     }
 
-    bitCapInt qPowers[n];
+    std::vector<bitCapInt> qPowers(n);
     for (i = 0; i < n; i++) {
         qPowers[i] = pow2(i);
     }
 
-    std::map<bitCapInt, int> goldStandardResult = goldStandard->MultiShotMeasureMask(qPowers, n, ITERATIONS);
+    std::map<bitCapInt, int> goldStandardResult = goldStandard->MultiShotMeasureMask(qPowers, ITERATIONS);
 
     std::map<bitCapInt, int>::iterator measurementBin;
 
@@ -3705,7 +3705,7 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
     crossEntropy = ONE_R1_F - sqrt(crossEntropy) / ITERATIONS;
     std::cout << "Gold standard vs. uniform random cross entropy (out of 1.0): " << crossEntropy << std::endl;
 
-    std::map<bitCapInt, int> goldStandardResult2 = goldStandard->MultiShotMeasureMask(qPowers, n, ITERATIONS);
+    std::map<bitCapInt, int> goldStandardResult2 = goldStandard->MultiShotMeasureMask(qPowers, ITERATIONS);
 
     int testBinResult;
     crossEntropy = ZERO_R1_F;
@@ -3846,7 +3846,7 @@ TEST_CASE("test_universal_circuit_digital_cross_entropy", "[supreme]")
             }
         }
     }
-    testCaseResult2 = testCase->MultiShotMeasureMask(qPowers, n, ITERATIONS);
+    testCaseResult2 = testCase->MultiShotMeasureMask(qPowers, ITERATIONS);
 
     crossEntropy = ZERO_R1_F;
     for (perm = 0; perm < permCount; perm++) {

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3262,11 +3262,12 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_forcem")
 
     const std::vector<bitLenInt> bits{ 0, 1, 2 };
     const std::vector<bitLenInt> bit{ 0 };
-    bool results[3] = { 0, 1, 0 };
+    const std::vector<bool> results{ 0, 1, 0 };
+    const std::vector<bool> result{ 0 };
 
-    qftReg->ForceM(bit, results);
+    qftReg->ForceM(bit, result);
     qftReg->ForceM(bits, results);
-    qftReg->ForceM(bit, NULL);
+    qftReg->ForceM(bit, std::vector<bool>());
     qftReg->ForceMReg(0, 1, results[0], false);
 
     REQUIRE(qftReg->ProbMask(0x7, 0x2) > 0.99);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -142,8 +142,8 @@ TEST_CASE("test_complex")
 TEST_CASE("test_push_apart_bits")
 {
     bitCapInt perm = 0x13U;
-    bitCapInt skipPowers[1] = { 1U << 2U };
-    REQUIRE(pushApartBits(perm, skipPowers, 1U) == 0x23U);
+    const std::vector<bitCapInt> skipPowers{ 1U << 2U };
+    REQUIRE(pushApartBits(perm, skipPowers) == 0x23U);
 }
 
 #if UINTPOW > 3
@@ -242,7 +242,7 @@ TEST_CASE("test_qengine_cpu_par_for_mask")
     std::atomic_bool hit[NUM_ENTRIES];
     std::atomic_int calls;
 
-    bitCapIntOcl skipArray[] = { 0x4, 0x100 }; // Skip bits 0b100000100
+    const std::vector<bitCapIntOcl> skipArray{ 0x4, 0x100 }; // Skip bits 0b100000100
     int NUM_SKIP = sizeof(skipArray) / sizeof(skipArray[0]);
 
     calls.store(0);
@@ -253,7 +253,7 @@ TEST_CASE("test_qengine_cpu_par_for_mask")
 
     qengine->SetConcurrencyLevel(1);
 
-    qengine->par_for_mask(0, NUM_ENTRIES, skipArray, 2, [&](const bitCapInt lcv, const int cpu) {
+    qengine->par_for_mask(0, NUM_ENTRIES, skipArray, [&](const bitCapInt lcv, const int cpu) {
         bool old = true;
         old = hit[(bitCapIntOcl)lcv].exchange(old);
         REQUIRE(old == false);
@@ -425,12 +425,12 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticnot")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticy")
 {
-    bitLenInt controls[1] = { 0 };
+    const std::vector<bitLenInt> controls{ 0 };
 
     qftReg->SetPermutation(0x01);
     qftReg->H(0, 2);
     qftReg->AntiCY(0, 1);
-    qftReg->MACInvert(controls, 1, -I_CMPLX, I_CMPLX, 1);
+    qftReg->MACInvert(controls, -I_CMPLX, I_CMPLX, 1);
     qftReg->H(0, 2);
     REQUIRE_THAT(qftReg, HasProbability(0x01));
 
@@ -438,68 +438,68 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticy")
     qftReg->H(0, 2);
     qftReg->Z(0);
     qftReg->AntiCY(0, 1);
-    qftReg->MACInvert(controls, 1, -I_CMPLX, I_CMPLX, 1);
+    qftReg->MACInvert(controls, -I_CMPLX, I_CMPLX, 1);
     qftReg->H(0, 2);
     REQUIRE_THAT(qftReg, HasProbability(0x01));
 
     qftReg->SetPermutation(0x00);
     qftReg->H(0, 2);
     qftReg->AntiCY(0, 1);
-    qftReg->MACInvert(controls, 1, -I_CMPLX, I_CMPLX, 1);
+    qftReg->MACInvert(controls, -I_CMPLX, I_CMPLX, 1);
     qftReg->H(0, 2);
     REQUIRE_THAT(qftReg, HasProbability(0x00));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_ccnot")
 {
-    bitLenInt controls[2] = { 0, 1 };
+    const std::vector<bitLenInt> controls{ 0, 1 };
 
     qftReg->SetPermutation(0x03);
     qftReg->H(0, 3);
     qftReg->CCNOT(0, 1, 2);
     qftReg->H(2);
-    qftReg->MCPhase(controls, 2, ONE_CMPLX, -ONE_CMPLX, 2);
+    qftReg->MCPhase(controls, ONE_CMPLX, -ONE_CMPLX, 2);
     qftReg->H(0, 2);
     REQUIRE_THAT(qftReg, HasProbability(0x03));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticcnot")
 {
-    bitLenInt controls[2] = { 0, 1 };
+    const std::vector<bitLenInt> controls{ 0, 1 };
 
     qftReg->SetPermutation(0x00);
     qftReg->H(0, 3);
     qftReg->AntiCCNOT(0, 1, 2);
     qftReg->H(2);
-    qftReg->MACPhase(controls, 2, ONE_CMPLX, -ONE_CMPLX, 2);
+    qftReg->MACPhase(controls, ONE_CMPLX, -ONE_CMPLX, 2);
     qftReg->H(0, 2);
     REQUIRE_THAT(qftReg, HasProbability(0x00));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticcy")
 {
-    bitLenInt controls[2] = { 0, 1 };
+    const std::vector<bitLenInt> controls{ 0, 1 };
 
     qftReg->SetPermutation(0x00);
     qftReg->H(0, 3);
     qftReg->AntiCCY(0, 1, 2);
-    qftReg->MACPhase(controls, 2, I_CMPLX, -I_CMPLX, 2);
+    qftReg->MACPhase(controls, I_CMPLX, -I_CMPLX, 2);
     qftReg->H(2);
-    qftReg->MACPhase(controls, 2, ONE_CMPLX, -ONE_CMPLX, 2);
+    qftReg->MACPhase(controls, ONE_CMPLX, -ONE_CMPLX, 2);
     qftReg->H(0, 2);
     REQUIRE_THAT(qftReg, HasProbability(0x00));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticcz")
 {
-    bitLenInt controls[2] = { 0, 1 };
+    const std::vector<bitLenInt> controls{ 0, 1 };
 
     qftReg->SetPermutation(0x00);
     qftReg->H(0, 3);
     qftReg->AntiCCZ(0, 1, 2);
-    qftReg->MACPhase(controls, 2, I_CMPLX, -I_CMPLX, 2);
+    qftReg->MACPhase(controls, I_CMPLX, -I_CMPLX, 2);
     qftReg->H(2);
-    qftReg->MACPhase(controls, 2, ONE_CMPLX, -ONE_CMPLX, 2);
+    qftReg->MACPhase(controls, ONE_CMPLX, -ONE_CMPLX, 2);
     qftReg->H(0, 2);
     REQUIRE_THAT(qftReg, HasProbability(0x00));
 }
@@ -558,16 +558,16 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_Iiswap")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_cswap")
 {
-    bitLenInt control[1] = { 8 };
+    std::vector<bitLenInt> control{ 8 };
     qftReg->SetPermutation(0x001);
-    qftReg->CSwap(control, 1, 0, 4);
+    qftReg->CSwap(control, 0, 4);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x001));
     qftReg->SetPermutation(0x101);
-    qftReg->CSwap(control, 1, 0, 4);
+    qftReg->CSwap(control, 0, 4);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x110));
     qftReg->H(8);
-    qftReg->CSwap(control, 1, 0, 4);
-    qftReg->CSwap(control, 1, 0, 4);
+    qftReg->CSwap(control, 0, 4);
+    qftReg->CSwap(control, 0, 4);
     qftReg->H(8);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x110));
 
@@ -577,98 +577,98 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cswap")
 
     control[0] = 9;
     qftReg2->SetPermutation((1U << 9U) | (1U << 10U));
-    qftReg2->CSwap(control, 1, 10, 11);
+    qftReg2->CSwap(control, 10, 11);
     REQUIRE_THAT(qftReg2, HasProbability(0, 12, (1U << 9U) | (1U << 11U)));
 
     qftReg2->SetPermutation((1U << 9U) | (1U << 10U));
-    qftReg2->CSwap(control, 1, 10, 0);
+    qftReg2->CSwap(control, 10, 0);
     REQUIRE_THAT(qftReg2, HasProbability(0, 12, (1U << 9U) | 1U));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticswap")
 {
-    bitLenInt control[1] = { 8 };
+    const std::vector<bitLenInt> control{ 8 };
     qftReg->SetPermutation(0x101);
-    qftReg->AntiCSwap(control, 1, 0, 4);
+    qftReg->AntiCSwap(control, 0, 4);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x101));
     qftReg->SetPermutation(0x001);
-    qftReg->AntiCSwap(control, 1, 0, 4);
+    qftReg->AntiCSwap(control, 0, 4);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x010));
     qftReg->H(8);
-    qftReg->AntiCSwap(control, 1, 0, 4);
-    qftReg->AntiCSwap(control, 1, 0, 4);
+    qftReg->AntiCSwap(control, 0, 4);
+    qftReg->AntiCSwap(control, 0, 4);
     qftReg->H(8);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x010));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_csqrtswap")
 {
-    bitLenInt control[1] = { 8 };
+    const std::vector<bitLenInt> control{ 8 };
     qftReg->SetPermutation(0x001);
-    qftReg->CSqrtSwap(control, 1, 0, 4);
-    qftReg->CSqrtSwap(control, 1, 0, 4);
+    qftReg->CSqrtSwap(control, 0, 4);
+    qftReg->CSqrtSwap(control, 0, 4);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x001));
     qftReg->SetPermutation(0x101);
-    qftReg->CSqrtSwap(control, 1, 0, 4);
-    qftReg->CSqrtSwap(control, 1, 0, 4);
+    qftReg->CSqrtSwap(control, 0, 4);
+    qftReg->CSqrtSwap(control, 0, 4);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x110));
     qftReg->H(8);
-    qftReg->CSqrtSwap(control, 1, 0, 4);
-    qftReg->CSqrtSwap(control, 1, 0, 4);
-    qftReg->CSqrtSwap(control, 1, 0, 4);
-    qftReg->CSqrtSwap(control, 1, 0, 4);
+    qftReg->CSqrtSwap(control, 0, 4);
+    qftReg->CSqrtSwap(control, 0, 4);
+    qftReg->CSqrtSwap(control, 0, 4);
+    qftReg->CSqrtSwap(control, 0, 4);
     qftReg->H(8);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x110));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticsqrtswap")
 {
-    bitLenInt control[1] = { 8 };
+    const std::vector<bitLenInt> control{ 8 };
     qftReg->SetPermutation(0x101);
-    qftReg->AntiCSqrtSwap(control, 1, 0, 4);
-    qftReg->AntiCSqrtSwap(control, 1, 0, 4);
+    qftReg->AntiCSqrtSwap(control, 0, 4);
+    qftReg->AntiCSqrtSwap(control, 0, 4);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x101));
     qftReg->SetPermutation(0x001);
-    qftReg->AntiCSqrtSwap(control, 1, 0, 4);
-    qftReg->AntiCSqrtSwap(control, 1, 0, 4);
+    qftReg->AntiCSqrtSwap(control, 0, 4);
+    qftReg->AntiCSqrtSwap(control, 0, 4);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x010));
     qftReg->H(8);
-    qftReg->AntiCSqrtSwap(control, 1, 0, 4);
-    qftReg->AntiCSqrtSwap(control, 1, 0, 4);
-    qftReg->AntiCSqrtSwap(control, 1, 0, 4);
-    qftReg->AntiCSqrtSwap(control, 1, 0, 4);
+    qftReg->AntiCSqrtSwap(control, 0, 4);
+    qftReg->AntiCSqrtSwap(control, 0, 4);
+    qftReg->AntiCSqrtSwap(control, 0, 4);
+    qftReg->AntiCSqrtSwap(control, 0, 4);
     qftReg->H(8);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x010));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_cisqrtswap")
 {
-    bitLenInt control[1] = { 8 };
+    const std::vector<bitLenInt> control{ 8 };
     qftReg->SetPermutation(0x101);
-    qftReg->CSqrtSwap(control, 1, 0, 4);
-    qftReg->CISqrtSwap(control, 1, 0, 4);
+    qftReg->CSqrtSwap(control, 0, 4);
+    qftReg->CISqrtSwap(control, 0, 4);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x101));
     qftReg->H(8);
-    qftReg->CISqrtSwap(control, 1, 0, 4);
-    qftReg->CISqrtSwap(control, 1, 0, 4);
-    qftReg->CISqrtSwap(control, 1, 0, 4);
-    qftReg->CISqrtSwap(control, 1, 0, 4);
+    qftReg->CISqrtSwap(control, 0, 4);
+    qftReg->CISqrtSwap(control, 0, 4);
+    qftReg->CISqrtSwap(control, 0, 4);
+    qftReg->CISqrtSwap(control, 0, 4);
     qftReg->H(8);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x101));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_anticisqrtswap")
 {
-    bitLenInt control[1] = { 8 };
+    const std::vector<bitLenInt> control{ 8 };
     qftReg->SetPermutation(0x001);
-    qftReg->AntiCSqrtSwap(control, 1, 0, 4);
-    qftReg->AntiCISqrtSwap(control, 1, 0, 4);
+    qftReg->AntiCSqrtSwap(control, 0, 4);
+    qftReg->AntiCISqrtSwap(control, 0, 4);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x001));
     qftReg->H(8);
-    qftReg->AntiCISqrtSwap(control, 1, 0, 4);
-    qftReg->AntiCISqrtSwap(control, 1, 0, 4);
-    qftReg->AntiCISqrtSwap(control, 1, 0, 4);
-    qftReg->AntiCISqrtSwap(control, 1, 0, 4);
+    qftReg->AntiCISqrtSwap(control, 0, 4);
+    qftReg->AntiCISqrtSwap(control, 0, 4);
+    qftReg->AntiCISqrtSwap(control, 0, 4);
+    qftReg->AntiCISqrtSwap(control, 0, 4);
     qftReg->H(8);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x001));
 }
@@ -710,7 +710,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_fsim")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_apply_single_bit")
 {
-    complex pauliX[4] = { ZERO_CMPLX, ONE_CMPLX, ONE_CMPLX, ZERO_CMPLX };
+    const complex pauliX[4]{ ZERO_CMPLX, ONE_CMPLX, ONE_CMPLX, ZERO_CMPLX };
     qftReg->SetPermutation(0x80001);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
     qftReg->Mtrx(pauliX, 19);
@@ -721,122 +721,122 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_apply_single_bit")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_apply_controlled_single_bit")
 {
-    complex pauliX[4] = { ZERO_CMPLX, ONE_CMPLX, ONE_CMPLX, ZERO_CMPLX };
-    bitLenInt controls[3] = { 0, 1, 3 };
+    const complex pauliX[4]{ ZERO_CMPLX, ONE_CMPLX, ONE_CMPLX, ZERO_CMPLX };
+    const std::vector<bitLenInt> controls{ 0, 1, 3 };
     qftReg->SetPermutation(0x8000F);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x8000F));
-    qftReg->MCMtrx(controls, 3, pauliX, 19);
+    qftReg->MCMtrx(controls, pauliX, 19);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x0F));
     qftReg->SetPermutation(0x80001);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
-    qftReg->MCMtrx(controls, 3, pauliX, 19);
+    qftReg->MCMtrx(controls, pauliX, 19);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
     qftReg->H(0);
     qftReg->H(1);
     qftReg->H(3);
-    qftReg->MCMtrx(controls, 3, pauliX, 19);
-    qftReg->MCMtrx(controls, 3, pauliX, 19);
+    qftReg->MCMtrx(controls, pauliX, 19);
+    qftReg->MCMtrx(controls, pauliX, 19);
     qftReg->H(0);
     qftReg->H(1);
     qftReg->H(3);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
-    qftReg->MCMtrx(NULL, 0, pauliX, 0);
+    qftReg->MCMtrx(std::vector<bitLenInt>(), pauliX, 0);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80000));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_apply_controlled_single_invert")
 {
-    complex topRight = ONE_CMPLX;
-    complex bottomLeft = ONE_CMPLX;
-    bitLenInt controls[3] = { 0, 1, 3 };
+    const complex topRight = ONE_CMPLX;
+    const complex bottomLeft = ONE_CMPLX;
+    const std::vector<bitLenInt> controls{ 0, 1, 3 };
     qftReg->SetPermutation(0x8000F);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x8000F));
-    qftReg->MCInvert(controls, 3, topRight, bottomLeft, 19);
+    qftReg->MCInvert(controls, topRight, bottomLeft, 19);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x0F));
     qftReg->SetPermutation(0x80001);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
-    qftReg->MCInvert(controls, 3, topRight, bottomLeft, 19);
+    qftReg->MCInvert(controls, topRight, bottomLeft, 19);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
     qftReg->H(0);
     qftReg->H(1);
     qftReg->H(3);
-    qftReg->MCInvert(controls, 3, topRight, bottomLeft, 19);
-    qftReg->MCInvert(controls, 3, topRight, bottomLeft, 19);
+    qftReg->MCInvert(controls, topRight, bottomLeft, 19);
+    qftReg->MCInvert(controls, topRight, bottomLeft, 19);
     qftReg->H(0);
     qftReg->H(1);
     qftReg->H(3);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
-    qftReg->MCInvert(NULL, 0, topRight, bottomLeft, 0);
+    qftReg->MCInvert(std::vector<bitLenInt>(), topRight, bottomLeft, 0);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80000));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_apply_anticontrolled_single_bit")
 {
-    complex pauliX[4] = { ZERO_CMPLX, ONE_CMPLX, ONE_CMPLX, ZERO_CMPLX };
-    bitLenInt controls[3] = { 0, 1, 3 };
+    const complex pauliX[4]{ ZERO_CMPLX, ONE_CMPLX, ONE_CMPLX, ZERO_CMPLX };
+    const std::vector<bitLenInt> controls{ 0, 1, 3 };
     qftReg->SetPermutation(0x80000);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80000));
-    qftReg->MACMtrx(controls, 3, pauliX, 19);
+    qftReg->MACMtrx(controls, pauliX, 19);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x00));
     qftReg->SetPermutation(0x80001);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
-    qftReg->MACMtrx(controls, 3, pauliX, 19);
+    qftReg->MACMtrx(controls, pauliX, 19);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
     qftReg->H(0);
     qftReg->H(1);
     qftReg->H(3);
-    qftReg->MACMtrx(controls, 3, pauliX, 19);
-    qftReg->MACMtrx(controls, 3, pauliX, 19);
+    qftReg->MACMtrx(controls, pauliX, 19);
+    qftReg->MACMtrx(controls, pauliX, 19);
     qftReg->H(0);
     qftReg->H(1);
     qftReg->H(3);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
-    qftReg->MACMtrx(NULL, 0, pauliX, 0);
+    qftReg->MACMtrx(std::vector<bitLenInt>(), pauliX, 0);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80000));
 
     qftReg->SetReg(0, 8, 0x02);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
     qftReg->H(0);
-    qftReg->MACPhase(NULL, 0, ONE_CMPLX, -ONE_CMPLX, 0);
+    qftReg->MACPhase(std::vector<bitLenInt>(), ONE_CMPLX, -ONE_CMPLX, 0);
     qftReg->H(0);
     qftReg->H(1);
-    qftReg->MACPhase(NULL, 0, ONE_CMPLX, -ONE_CMPLX, 1);
+    qftReg->MACPhase(std::vector<bitLenInt>(), ONE_CMPLX, -ONE_CMPLX, 1);
     qftReg->H(1);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_apply_anticontrolled_single_invert")
 {
-    complex topRight = ONE_CMPLX;
-    complex bottomLeft = ONE_CMPLX;
-    bitLenInt controls[3] = { 0, 1, 3 };
+    const complex topRight = ONE_CMPLX;
+    const complex bottomLeft = ONE_CMPLX;
+    const std::vector<bitLenInt> controls{ 0, 1, 3 };
     qftReg->SetPermutation(0x80000);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80000));
-    qftReg->MCInvert(controls, 3, topRight, bottomLeft, 19);
+    qftReg->MCInvert(controls, topRight, bottomLeft, 19);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80000));
     qftReg->SetPermutation(0x80001);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
-    qftReg->MCInvert(controls, 3, topRight, bottomLeft, 19);
+    qftReg->MCInvert(controls, topRight, bottomLeft, 19);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
     qftReg->H(0);
     qftReg->H(1);
     qftReg->H(3);
-    qftReg->MCInvert(controls, 3, topRight, bottomLeft, 19);
-    qftReg->MCInvert(controls, 3, topRight, bottomLeft, 19);
+    qftReg->MCInvert(controls, topRight, bottomLeft, 19);
+    qftReg->MCInvert(controls, topRight, bottomLeft, 19);
     qftReg->H(0);
     qftReg->H(1);
     qftReg->H(3);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80001));
-    qftReg->MCInvert(NULL, 0, topRight, bottomLeft, 0);
+    qftReg->MCInvert(std::vector<bitLenInt>(), topRight, bottomLeft, 0);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 0x80000));
 
     qftReg->SetReg(0, 8, 0x02);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
     qftReg->H(0);
-    qftReg->MACPhase(NULL, 0, ONE_CMPLX, -ONE_CMPLX, 0);
+    qftReg->MACPhase(std::vector<bitLenInt>(), ONE_CMPLX, -ONE_CMPLX, 0);
     qftReg->H(0);
     qftReg->H(1);
-    qftReg->MACPhase(NULL, 0, ONE_CMPLX, -ONE_CMPLX, 1);
+    qftReg->MACPhase(std::vector<bitLenInt>(), ONE_CMPLX, -ONE_CMPLX, 1);
     qftReg->H(1);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
 }
@@ -856,40 +856,40 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_apply_single_invert")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_apply_controlled_single_phase")
 {
-    bitLenInt controls[1] = { 0 };
+    const std::vector<bitLenInt> controls{ 0 };
 
     qftReg->SetPermutation(0x01);
     qftReg->H(1);
-    qftReg->MCPhase(NULL, 0U, ONE_CMPLX, -ONE_CMPLX, 1U);
+    qftReg->MCPhase(std::vector<bitLenInt>(), ONE_CMPLX, -ONE_CMPLX, 1U);
     qftReg->H(1);
     REQUIRE_THAT(qftReg, HasProbability(0x03));
 
     qftReg->SetPermutation(0x01);
     qftReg->H(1);
-    qftReg->MCPhase(controls, 1U, ONE_CMPLX, -ONE_CMPLX, 1U);
+    qftReg->MCPhase(controls, ONE_CMPLX, -ONE_CMPLX, 1U);
     qftReg->H(1);
     REQUIRE_THAT(qftReg, HasProbability(0x03));
 
     qftReg->SetPermutation(0x01);
     qftReg->H(1);
-    qftReg->MCPhase(controls, 1U, ONE_CMPLX, ONE_CMPLX, 1U);
+    qftReg->MCPhase(controls, ONE_CMPLX, ONE_CMPLX, 1U);
     qftReg->H(1);
     REQUIRE_THAT(qftReg, HasProbability(0x01));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_apply_anti_controlled_single_phase")
 {
-    bitLenInt controls[1] = { 0 };
+    const std::vector<bitLenInt> controls{ 0 };
 
     qftReg->SetPermutation(0x00);
     qftReg->H(1);
-    qftReg->MACPhase(NULL, 0U, ONE_CMPLX, -ONE_CMPLX, 1U);
+    qftReg->MACPhase(std::vector<bitLenInt>(), ONE_CMPLX, -ONE_CMPLX, 1U);
     qftReg->H(1);
     REQUIRE_THAT(qftReg, HasProbability(0x02));
 
     qftReg->SetPermutation(0x00);
     qftReg->H(1);
-    qftReg->MACPhase(controls, 1U, ONE_CMPLX, -ONE_CMPLX, 1U);
+    qftReg->MACPhase(controls, ONE_CMPLX, -ONE_CMPLX, 1U);
     qftReg->H(1);
     REQUIRE_THAT(qftReg, HasProbability(0x02));
 }
@@ -1293,14 +1293,14 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cy")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_ccy")
 {
-    bitLenInt controls[2] = { 0, 1 };
+    const std::vector<bitLenInt> controls{ 0, 1 };
 
     qftReg->SetPermutation(0x03);
     qftReg->H(0, 3);
     qftReg->CCY(0, 1, 2);
-    qftReg->MCPhase(controls, 2, I_CMPLX, -I_CMPLX, 2);
+    qftReg->MCPhase(controls, I_CMPLX, -I_CMPLX, 2);
     qftReg->H(2);
-    qftReg->MCPhase(controls, 2, ONE_CMPLX, -ONE_CMPLX, 2);
+    qftReg->MCPhase(controls, ONE_CMPLX, -ONE_CMPLX, 2);
     qftReg->H(0, 2);
     REQUIRE_THAT(qftReg, HasProbability(0x03));
 }
@@ -1420,31 +1420,31 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_rz")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_cry")
 {
-    bitLenInt controls[2] = { 4, 5 };
+    std::vector<bitLenInt> controls{ 4, 5 };
     real1 angles[4] = { PI_R1, PI_R1, ZERO_R1, ZERO_R1 };
 
     qftReg->SetReg(0, 8, 0x02);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
-    qftReg->UniformlyControlledRY(NULL, 0, 0, angles);
-    qftReg->UniformlyControlledRY(NULL, 0, 1, angles);
+    qftReg->UniformlyControlledRY(std::vector<bitLenInt>(), 0, angles);
+    qftReg->UniformlyControlledRY(std::vector<bitLenInt>(), 1, angles);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
 
     qftReg->SetReg(0, 8, 0x02);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
-    qftReg->UniformlyControlledRY(controls, 2, 0, angles);
-    qftReg->UniformlyControlledRY(controls, 2, 1, angles);
+    qftReg->UniformlyControlledRY(controls, 0, angles);
+    qftReg->UniformlyControlledRY(controls, 1, angles);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
 
     qftReg->SetReg(0, 8, 0x12);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x12));
-    qftReg->UniformlyControlledRY(controls, 2, 0, angles);
-    qftReg->UniformlyControlledRY(controls, 2, 1, angles);
+    qftReg->UniformlyControlledRY(controls, 0, angles);
+    qftReg->UniformlyControlledRY(controls, 1, angles);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x11));
 
     qftReg->SetReg(0, 8, 0x22);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x22));
-    qftReg->UniformlyControlledRY(controls, 2, 0, angles);
-    qftReg->UniformlyControlledRY(controls, 2, 1, angles);
+    qftReg->UniformlyControlledRY(controls, 0, angles);
+    qftReg->UniformlyControlledRY(controls, 1, angles);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x22));
 
     controls[0] = 5;
@@ -1452,8 +1452,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_cry")
 
     qftReg->SetReg(0, 8, 0x22);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x22));
-    qftReg->UniformlyControlledRY(controls, 2, 0, angles);
-    qftReg->UniformlyControlledRY(controls, 2, 1, angles);
+    qftReg->UniformlyControlledRY(controls, 0, angles);
+    qftReg->UniformlyControlledRY(controls, 1, angles);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x21));
 
     controls[0] = 4;
@@ -1462,8 +1462,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_cry")
     qftReg->SetReg(0, 8, 0x02);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
     qftReg->H(4);
-    qftReg->UniformlyControlledRY(controls, 2, 0, angles);
-    qftReg->UniformlyControlledRY(controls, 2, 1, angles);
+    qftReg->UniformlyControlledRY(controls, 0, angles);
+    qftReg->UniformlyControlledRY(controls, 1, angles);
     qftReg->H(4);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
 
@@ -1473,8 +1473,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_cry")
     REQUIRE_THAT(qftReg2, HasProbability(0, 8, 0x02));
 
     if (!QINTERFACE_RESTRICTED) {
-        qftReg->UniformlyControlledRY(controls, 2, 0, angles);
-        qftReg2->QInterface::UniformlyControlledRY(controls, 2, 0, angles);
+        qftReg->UniformlyControlledRY(controls, 0, angles);
+        qftReg2->QInterface::UniformlyControlledRY(controls, 0, angles);
 
         REQUIRE(qftReg->ApproxCompare(qftReg2));
     }
@@ -1482,34 +1482,34 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_cry")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_crz")
 {
-    bitLenInt controls[2] = { 4, 5 };
+    std::vector<bitLenInt> controls{ 4, 5 };
     real1 angles[4] = { PI_R1, PI_R1, ZERO_R1, ZERO_R1 };
 
     qftReg->SetReg(0, 8, 0x01);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
     qftReg->H(1, 2);
-    qftReg->UniformlyControlledRZ(NULL, 0, 1, angles);
+    qftReg->UniformlyControlledRZ(std::vector<bitLenInt>(), 1, angles);
     qftReg->H(1, 2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x03));
 
     qftReg->SetReg(0, 8, 0x01);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
     qftReg->H(1, 2);
-    qftReg->UniformlyControlledRZ(controls, 2, 1, angles);
+    qftReg->UniformlyControlledRZ(controls, 1, angles);
     qftReg->H(1, 2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x03));
 
     qftReg->SetReg(0, 8, 0x11);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x11));
     qftReg->H(1, 2);
-    qftReg->UniformlyControlledRZ(controls, 2, 1, angles);
+    qftReg->UniformlyControlledRZ(controls, 1, angles);
     qftReg->H(1, 2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x13));
 
     qftReg->SetReg(0, 8, 0x21);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x21));
     qftReg->H(1, 2);
-    qftReg->UniformlyControlledRZ(controls, 2, 1, angles);
+    qftReg->UniformlyControlledRZ(controls, 1, angles);
     qftReg->H(1, 2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x21));
 
@@ -1519,7 +1519,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_crz")
     qftReg->SetReg(0, 8, 0x21);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x21));
     qftReg->H(1, 2);
-    qftReg->UniformlyControlledRZ(controls, 2, 1, angles);
+    qftReg->UniformlyControlledRZ(controls, 1, angles);
     qftReg->H(1, 2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x23));
 
@@ -1530,7 +1530,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_crz")
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
     qftReg->H(4);
     qftReg->H(1, 2);
-    qftReg->UniformlyControlledRZ(controls, 2, 1, angles);
+    qftReg->UniformlyControlledRZ(controls, 1, angles);
     qftReg->H(1, 2);
     qftReg->H(4);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x03));
@@ -1538,7 +1538,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_crz")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_c_single")
 {
-    bitLenInt controls[2] = { 4, 5 };
+    std::vector<bitLenInt> controls{ 4, 5 };
     real1 angles[4] = { PI_R1, PI_R1, ZERO_R1, ZERO_R1 };
     complex pauliRYs[16];
 
@@ -1555,33 +1555,33 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_c_single")
 
     qftReg->SetReg(0, 8, 0x02);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
-    qftReg->UniformlyControlledSingleBit(NULL, 0, 0, pauliRYs);
-    qftReg->UniformlyControlledSingleBit(NULL, 0, 1, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(std::vector<bitLenInt>(), 0, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(std::vector<bitLenInt>(), 1, pauliRYs);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
 
     qftReg->SetReg(0, 8, 0x02);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
-    qftReg->UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
-    qftReg->UniformlyControlledSingleBit(controls, 2, 1, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(controls, 0, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(controls, 1, pauliRYs);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
 
     qftReg->SetReg(0, 8, 0x12);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x12));
-    qftReg->UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
-    qftReg->UniformlyControlledSingleBit(controls, 2, 1, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(controls, 0, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(controls, 1, pauliRYs);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x11));
 
     qftReg->SetReg(0, 8, 0x22);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x22));
-    qftReg->UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
-    qftReg->UniformlyControlledSingleBit(controls, 2, 1, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(controls, 0, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(controls, 1, pauliRYs);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x22));
 
     qftReg->SetReg(0, 8, 0x22);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x22));
     qftReg->H(4);
-    qftReg->UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
-    qftReg->UniformlyControlledSingleBit(controls, 2, 1, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(controls, 0, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(controls, 1, pauliRYs);
     qftReg->H(4);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x22));
 
@@ -1590,8 +1590,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_c_single")
 
     qftReg->SetReg(0, 8, 0x22);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x22));
-    qftReg->UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
-    qftReg->UniformlyControlledSingleBit(controls, 2, 1, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(controls, 0, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(controls, 1, pauliRYs);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x21));
 
     controls[0] = 4;
@@ -1600,8 +1600,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_c_single")
     qftReg->SetReg(0, 8, 0x02);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
     qftReg->H(4);
-    qftReg->UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
-    qftReg->UniformlyControlledSingleBit(controls, 2, 1, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(controls, 0, pauliRYs);
+    qftReg->UniformlyControlledSingleBit(controls, 1, pauliRYs);
     qftReg->H(4);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
 
@@ -1611,8 +1611,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_c_single")
     REQUIRE_THAT(qftReg2, HasProbability(0, 8, 0x02));
 
     if (!QINTERFACE_RESTRICTED) {
-        qftReg->UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
-        qftReg2->QInterface::UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
+        qftReg->UniformlyControlledSingleBit(controls, 0, pauliRYs);
+        qftReg2->QInterface::UniformlyControlledSingleBit(controls, 0, pauliRYs);
 
         REQUIRE(qftReg->ApproxCompare(qftReg2));
 
@@ -1621,8 +1621,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniform_c_single")
         REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
         REQUIRE_THAT(qftReg2, HasProbability(0, 8, 0x02));
 
-        qftReg->UniformlyControlledSingleBit(controls, 2, 0, pauliRYs);
-        qftReg2->QInterface::UniformlyControlledSingleBit(controls, 2, 0, pauliRYs, NULL, 0, 0);
+        qftReg->UniformlyControlledSingleBit(controls, 0, pauliRYs);
+        qftReg2->QInterface::UniformlyControlledSingleBit(controls, 0, pauliRYs, std::vector<bitCapInt>(), 0);
 
         REQUIRE(qftReg->ApproxCompare(qftReg2));
     }
@@ -2748,8 +2748,6 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_tryseparate")
     const bool isStabilizerQBdt =
         (testSubSubEngineType == QINTERFACE_BDT) && (testSubEngineType == QINTERFACE_STABILIZER_HYBRID);
 
-    bitLenInt toSep[2];
-
     qftReg->SetPermutation(85);
 
     int i;
@@ -2761,8 +2759,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_tryseparate")
     for (i = 0; i < 8; i++) {
         qftReg->TrySeparate(i);
         if (!isStabilizerQBdt) {
-            toSep[0] = i;
-            qftReg->TrySeparate(toSep, 1, FP_NORM_EPSILON_F);
+            const std::vector<bitLenInt> toSep{ (bitLenInt)i };
+            qftReg->TrySeparate(toSep, FP_NORM_EPSILON_F);
         }
     }
 
@@ -2775,9 +2773,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_tryseparate")
     qftReg->CNOT(0, 2);
     qftReg->TrySeparate(0, 1);
     if (!isStabilizerQBdt) {
-        toSep[0] = 0;
-        toSep[1] = 1;
-        qftReg->TrySeparate(toSep, 2, FP_NORM_EPSILON_F);
+        const std::vector<bitLenInt> toSep{ 0, 1 };
+        qftReg->TrySeparate(toSep, FP_NORM_EPSILON_F);
     }
     qftReg->CNOT(0, 1);
     qftReg->Z(0);
@@ -2836,10 +2833,10 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_mreg")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_m_array")
 {
-    bitLenInt bits[3] = { 0, 2, 3 };
+    const std::vector<bitLenInt> bits{ 0, 2, 3 };
     REQUIRE(qftReg->M(0) == 0);
     qftReg->SetReg(0, 8, 0x07);
-    REQUIRE(qftReg->M(bits, 3) == 5);
+    REQUIRE(qftReg->M(bits) == 5);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x07));
 }
 
@@ -3087,9 +3084,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_probmaskall")
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_probbitsall")
 {
     qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 3, 5, rng);
-    bitLenInt bits[2] = { 2, 1 };
+    const std::vector<bitLenInt> bits{ 2, 1 };
     real1 probs1[4];
-    qftReg->ProbBitsAll(bits, 2U, probs1);
+    qftReg->ProbBitsAll(bits, probs1);
     REQUIRE(probs1[0] < 0.01);
     REQUIRE(probs1[1] > 0.99);
     REQUIRE(probs1[2] < 0.01);
@@ -3097,7 +3094,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_probbitsall")
 
     qftReg->H(2);
 
-    qftReg->ProbBitsAll(bits, 2U, probs1);
+    qftReg->ProbBitsAll(bits, probs1);
     REQUIRE_FLOAT((real1_f)probs1[0], 0.5);
     REQUIRE_FLOAT((real1_f)probs1[1], 0.5);
     REQUIRE(probs1[2] < 0.01);
@@ -3107,9 +3104,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_probbitsall")
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_expectationbitsall")
 {
     qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 8, 0, rng);
-    bitLenInt bits[8] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+    const std::vector<bitLenInt> bits{ 0, 1, 2, 3, 4, 5, 6, 7 };
     qftReg->H(0, 8);
-    REQUIRE_FLOAT(qftReg->ExpectationBitsAll(bits, 8U), 127 + (ONE_R1_F / 2))
+    REQUIRE_FLOAT(qftReg->ExpectationBitsAll(bits), 127 + (ONE_R1_F / 2))
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_probparity")
@@ -3198,36 +3195,37 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniformparityrz")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_cuniformparityrz")
 {
-    bitLenInt controls[2] = { 3, 4 };
+    const std::vector<bitLenInt> controls{ 3, 4 };
+    const std::vector<bitLenInt> control{ 3 };
 
     qftReg->SetPermutation(0);
     qftReg->H(0);
-    QPARITY(qftReg)->CUniformParityRZ(controls, 2, 1, M_PI_2);
+    QPARITY(qftReg)->CUniformParityRZ(controls, 1, M_PI_2);
     qftReg->H(0);
     REQUIRE_THAT(qftReg, HasProbability(0));
 
     qftReg->SetPermutation(0x18);
     qftReg->H(0);
-    QPARITY(qftReg)->CUniformParityRZ(controls, 2, 1, M_PI_2);
+    QPARITY(qftReg)->CUniformParityRZ(controls, 1, M_PI_2);
     qftReg->H(0);
     REQUIRE_THAT(qftReg, HasProbability(0x1 | 0x18));
 
     qftReg->SetPermutation(0x3 | 0x18);
     qftReg->H(0, 3);
-    QPARITY(qftReg)->CUniformParityRZ(controls, 1, 0x7, M_PI_2);
+    QPARITY(qftReg)->CUniformParityRZ(control, 0x7, M_PI_2);
     qftReg->H(0, 3);
     REQUIRE_THAT(qftReg, HasProbability(0x4 | 0x18));
 
     qftReg->SetPermutation(0x1 | 0x18);
     qftReg->H(0, 3);
-    QPARITY(qftReg)->CUniformParityRZ(controls, 2, 0x7, M_PI_2);
-    QPARITY(qftReg)->CUniformParityRZ(controls, 2, 0x7, M_PI_2);
+    QPARITY(qftReg)->CUniformParityRZ(controls, 0x7, M_PI_2);
+    QPARITY(qftReg)->CUniformParityRZ(controls, 0x7, M_PI_2);
     qftReg->H(0, 3);
     REQUIRE_THAT(qftReg, HasProbability(0x1 | 0x18));
 
     qftReg->SetPermutation(0x01 | 0x18);
     qftReg->H(0);
-    QPARITY(qftReg)->CUniformParityRZ(controls, 2, 1, M_PI_4);
+    QPARITY(qftReg)->CUniformParityRZ(controls, 1, M_PI_4);
     qftReg->S(0);
     qftReg->H(0);
     REQUIRE_THAT(qftReg, HasProbability(0x0 | 0x18));
@@ -3237,7 +3235,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_multishotmeasuremask")
 {
     qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 8, 0, rng);
 
-    bitCapInt qPowers[3] = { pow2(6), pow2(2), pow2(3) };
+    const std::vector<bitCapInt> qPowers{ pow2(6), pow2(2), pow2(3) };
 
     qftReg->SetPermutation(0);
     qftReg->H(6);
@@ -3246,7 +3244,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_multishotmeasuremask")
 
     const std::set<bitCapInt> possibleResults = { 2, 3, 6, 7 };
 
-    std::map<bitCapInt, int> results = qftReg->MultiShotMeasureMask(qPowers, 3U, 1000);
+    std::map<bitCapInt, int> results = qftReg->MultiShotMeasureMask(qPowers, 1000);
     std::map<bitCapInt, int>::iterator it = results.begin();
     while (it != results.end()) {
         REQUIRE(possibleResults.find(it->first) != possibleResults.end());
@@ -3262,12 +3260,13 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_forcem")
     REQUIRE_FLOAT(qftReg->ProbMask(0xF, 0), 0.0625);
     REQUIRE_FLOAT(qftReg->ProbMask(0x7, 0), 0.125);
 
-    bitLenInt bits[3] = { 0, 1, 2 };
+    const std::vector<bitLenInt> bits{ 0, 1, 2 };
+    const std::vector<bitLenInt> bit{ 0 };
     bool results[3] = { 0, 1, 0 };
 
-    qftReg->ForceM(bits, 1, results);
-    qftReg->ForceM(bits, 3, results);
-    qftReg->ForceM(bits, 1, NULL);
+    qftReg->ForceM(bit, results);
+    qftReg->ForceM(bits, results);
+    qftReg->ForceM(bit, NULL);
     qftReg->ForceMReg(0, 1, results[0], false);
 
     REQUIRE(qftReg->ProbMask(0x7, 0x2) > 0.99);
@@ -3560,41 +3559,41 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_iadc")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_cfulladd")
 {
-    bitLenInt control[1] = { 10 };
+    const std::vector<bitLenInt> control{ 10 };
     qftReg->SetPermutation(0x00); // off
-    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CFullAdd(control, 0, 1, 2, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0));
 
     qftReg->SetPermutation(0x01);
     qftReg->X(control[0]); // on
-    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CFullAdd(control, 0, 1, 2, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x05));
 
     qftReg->SetPermutation(0x02); // off
-    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CFullAdd(control, 0, 1, 2, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
 
     qftReg->SetPermutation(0x03);
     qftReg->X(control[0]); // on
-    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CFullAdd(control, 0, 1, 2, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x0B));
 
     qftReg->SetPermutation(0x04); // off
-    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CFullAdd(control, 0, 1, 2, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x04));
 
     qftReg->SetPermutation(0x05);
     qftReg->X(control[0]); // on
-    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CFullAdd(control, 0, 1, 2, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x09));
 
     qftReg->SetPermutation(0x06); // off
-    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CFullAdd(control, 0, 1, 2, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x06));
 
     qftReg->SetPermutation(0x07);
     qftReg->X(control[0]); // on
-    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CFullAdd(control, 0, 1, 2, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x0F));
 }
 
@@ -3602,61 +3601,61 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cifulladd")
 {
     // This is contingent on the previous test passing.
 
-    bitLenInt control[1] = { 10 };
+    const std::vector<bitLenInt> control{ 10 };
 
     qftReg->SetPermutation(0x00); // off
-    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
-    qftReg->CIFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CFullAdd(control, 0, 1, 2, 3);
+    qftReg->CIFullAdd(control, 0, 1, 2, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0));
 
     qftReg->SetPermutation(0x01);
     qftReg->X(control[0]); // on
-    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
-    qftReg->CIFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CFullAdd(control, 0, 1, 2, 3);
+    qftReg->CIFullAdd(control, 0, 1, 2, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x01));
 
     qftReg->SetPermutation(0x02); // off
-    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
-    qftReg->CIFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CFullAdd(control, 0, 1, 2, 3);
+    qftReg->CIFullAdd(control, 0, 1, 2, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x02));
 
     qftReg->SetPermutation(0x03);
     qftReg->X(control[0]); // on
-    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
-    qftReg->CIFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CFullAdd(control, 0, 1, 2, 3);
+    qftReg->CIFullAdd(control, 0, 1, 2, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x03));
 
     qftReg->SetPermutation(0x04); // off
-    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
-    qftReg->CIFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CFullAdd(control, 0, 1, 2, 3);
+    qftReg->CIFullAdd(control, 0, 1, 2, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x04));
 
     qftReg->SetPermutation(0x05);
     qftReg->X(control[0]); // on
-    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
-    qftReg->CIFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CFullAdd(control, 0, 1, 2, 3);
+    qftReg->CIFullAdd(control, 0, 1, 2, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x05));
 
     qftReg->X(control[0]); // off
 
     qftReg->SetPermutation(0x06);
-    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
-    qftReg->CIFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CFullAdd(control, 0, 1, 2, 3);
+    qftReg->CIFullAdd(control, 0, 1, 2, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x06));
 
     qftReg->SetPermutation(0x07); // off
-    qftReg->CFullAdd(control, 1, 0, 1, 2, 3);
-    qftReg->CIFullAdd(control, 1, 0, 1, 2, 3);
+    qftReg->CFullAdd(control, 0, 1, 2, 3);
+    qftReg->CIFullAdd(control, 0, 1, 2, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0x07));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_cadc")
 {
-    bitLenInt control[1] = { 10 };
+    const std::vector<bitLenInt> control{ 10 };
 
     qftReg->SetPermutation(0); // off
     qftReg->H(2, 2);
-    qftReg->CADC(control, 1, 0, 2, 4, 2, 6);
+    qftReg->CADC(control, 0, 2, 4, 2, 6);
     qftReg->H(2, 2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0));
 
@@ -3664,31 +3663,31 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cadc")
     qftReg->X(control[0]); // on
     qftReg->H(0);
     qftReg->CNOT(0, 2);
-    qftReg->CADC(control, 1, 0, 2, 4, 2, 6);
-    qftReg->CIADC(control, 1, 0, 2, 4, 2, 6);
+    qftReg->CADC(control, 0, 2, 4, 2, 6);
+    qftReg->CIADC(control, 0, 2, 4, 2, 6);
     qftReg->CNOT(0, 2);
     qftReg->H(0);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0));
 
     qftReg->SetPermutation(1);
     qftReg->X(control[0]); // on
-    qftReg->CADC(control, 1, 0, 1, 2, 1, 3);
+    qftReg->CADC(control, 0, 1, 2, 1, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 5));
 
     qftReg->SetPermutation(1); // off
-    qftReg->CADC(control, 1, 0, 1, 2, 0, 3);
+    qftReg->CADC(control, 0, 1, 2, 0, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 1));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_ciadc")
 {
     // This is contingent on the previous test passing.
-    bitLenInt control[1] = { 10 };
+    const std::vector<bitLenInt> control{ 10 };
 
     qftReg->SetPermutation(8); // off
     qftReg->H(2, 2);
-    qftReg->CADC(control, 1, 0, 2, 4, 2, 6);
-    qftReg->CIADC(control, 1, 0, 2, 4, 2, 6);
+    qftReg->CADC(control, 0, 2, 4, 2, 6);
+    qftReg->CIADC(control, 0, 2, 4, 2, 6);
     qftReg->H(2, 2);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 8));
 
@@ -3696,23 +3695,23 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_ciadc")
     qftReg->X(control[0]); // on
     qftReg->H(0);
     qftReg->CNOT(0, 2);
-    qftReg->CADC(control, 1, 0, 2, 4, 2, 6);
-    qftReg->CIADC(control, 1, 0, 2, 4, 2, 6);
+    qftReg->CADC(control, 0, 2, 4, 2, 6);
+    qftReg->CIADC(control, 0, 2, 4, 2, 6);
     qftReg->CNOT(0, 2);
     qftReg->H(0);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 0));
 
     qftReg->SetPermutation(2);
     qftReg->X(control[0]); // on
-    qftReg->CADC(control, 1, 0, 1, 2, 1, 3);
+    qftReg->CADC(control, 0, 1, 2, 1, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 6));
-    qftReg->CIADC(control, 1, 0, 1, 2, 1, 3);
+    qftReg->CIADC(control, 0, 1, 2, 1, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 2));
 
     qftReg->SetPermutation(2); // off
-    qftReg->CADC(control, 1, 0, 1, 2, 0, 3);
+    qftReg->CADC(control, 0, 1, 2, 0, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 2));
-    qftReg->CIADC(control, 1, 0, 1, 2, 0, 3);
+    qftReg->CIADC(control, 0, 1, 2, 0, 3);
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 2));
 }
 
@@ -3906,10 +3905,10 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cinc", "[travis_xfail]")
 {
 
     qftReg->SetPermutation(1);
-    QALU(qftReg)->CINC(1, 0, 8, NULL, 0);
+    QALU(qftReg)->CINC(1, 0, 8, std::vector<bitLenInt>());
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 2));
 
-    bitLenInt controls[1] = { 8 };
+    const std::vector<bitLenInt> controls{ 8 };
 
     qftReg->SetPermutation(250);
 
@@ -3917,7 +3916,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cinc", "[travis_xfail]")
         // Turn control on
         qftReg->X(controls[0]);
 
-        QALU(qftReg)->CINC(1, 0, 8, controls, 1);
+        QALU(qftReg)->CINC(1, 0, 8, controls);
         if (i < 5) {
             REQUIRE_THAT(qftReg, HasProbability(0, 8, 251 + i));
         } else {
@@ -3927,7 +3926,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cinc", "[travis_xfail]")
         // Turn control off
         qftReg->X(controls[0]);
 
-        QALU(qftReg)->CINC(1, 0, 8, controls, 1);
+        QALU(qftReg)->CINC(1, 0, 8, controls);
         if (i < 5) {
             REQUIRE_THAT(qftReg, HasProbability(0, 8, 251 + i));
         } else {
@@ -3942,7 +3941,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_dec")
     int start = 0x08;
 
     qftReg->SetPermutation(2);
-    QALU(qftReg)->CDEC(1, 0, 8, NULL, 0);
+    QALU(qftReg)->CDEC(1, 0, 8, std::vector<bitLenInt>());
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 1));
 
     qftReg->SetPermutation(start);
@@ -4026,20 +4025,20 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cdec", "[travis_xfail]")
 {
     int i;
 
-    bitLenInt controls[1] = { 8 };
+    const std::vector<bitLenInt> controls{ 8 };
 
     qftReg->SetPermutation(0x08);
     for (i = 0; i < 8; i++) {
         // Turn control on
         qftReg->X(controls[0]);
 
-        QALU(qftReg)->CDEC(9, 0, 8, controls, 1);
+        QALU(qftReg)->CDEC(9, 0, 8, controls);
         REQUIRE_THAT(qftReg, HasProbability(0, 8, 0xff - i * 9));
 
         // Turn control off
         qftReg->X(controls[0]);
 
-        QALU(qftReg)->CDEC(9, 0, 8, controls, 1);
+        QALU(qftReg)->CDEC(9, 0, 8, controls);
         REQUIRE_THAT(qftReg, HasProbability(0, 8, 0xff - i * 9));
     }
 }
@@ -4221,16 +4220,16 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cmul")
 {
     int i;
 
-    bitLenInt controls[1] = { 16 };
+    const std::vector<bitLenInt> controls{ 16 };
 
     qftReg->SetPermutation(1);
-    QALU(qftReg)->CMUL(2, 0, 8, 8, NULL, 0);
+    QALU(qftReg)->CMUL(2, 0, 8, 8, std::vector<bitLenInt>());
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 2));
 
     qftReg->SetPermutation(3 | (1 << 16));
     bitCapInt res = 3;
     for (i = 0; i < 8; i++) {
-        QALU(qftReg)->CMUL(2, 0, 8, 8, controls, 1);
+        QALU(qftReg)->CMUL(2, 0, 8, 8, controls);
         if ((i % 2) == 0) {
             res *= 2;
         }
@@ -4244,16 +4243,16 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cdiv")
 {
     int i;
 
-    bitLenInt controls[1] = { 16 };
+    const std::vector<bitLenInt> controls{ 16 };
 
     qftReg->SetPermutation(2);
-    QALU(qftReg)->CDIV(2, 0, 8, 8, NULL, 0);
+    QALU(qftReg)->CDIV(2, 0, 8, 8, std::vector<bitLenInt>());
     REQUIRE_THAT(qftReg, HasProbability(0, 8, 1));
 
     qftReg->SetPermutation(256 | (1 << 16));
     bitCapInt res = 256;
     for (i = 0; i < 8; i++) {
-        QALU(qftReg)->CDIV(2, 0, 8, 8, controls, 1);
+        QALU(qftReg)->CDIV(2, 0, 8, 8, controls);
         if ((i % 2) == 0) {
             res /= 2;
         }
@@ -4264,71 +4263,71 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_cdiv")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_cmulmodnout", "[travis_xfail]")
 {
-    bitLenInt controls[1] = { 16 };
+    const std::vector<bitLenInt> controls{ 16 };
 
     qftReg->SetPermutation(1);
-    QALU(qftReg)->CMULModNOut(2, 256U, 0, 8, 8, NULL, 0);
+    QALU(qftReg)->CMULModNOut(2, 256U, 0, 8, 8, std::vector<bitLenInt>());
     REQUIRE_THAT(qftReg, HasProbability(0, 16, 1 | (2 << 8)));
 
     qftReg->SetPermutation(3 | (1 << 16));
-    QALU(qftReg)->CMULModNOut(3, 256U, 0, 8, 8, controls, 1);
+    QALU(qftReg)->CMULModNOut(3, 256U, 0, 8, 8, controls);
     REQUIRE_THAT(qftReg, HasProbability(0, 16, 3 | (9 << 8)));
 
     qftReg->SetPermutation(3);
     qftReg->H(16);
-    QALU(qftReg)->CMULModNOut(3, 256U, 0, 8, 8, controls, 1);
+    QALU(qftReg)->CMULModNOut(3, 256U, 0, 8, 8, controls);
     REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(3));
     REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(3 | (9 << 8) | (1 << 16)));
 
     qftReg->SetPermutation(65 | (1 << 16));
-    QALU(qftReg)->CMULModNOut(5, 125U, 0, 8, 8, controls, 1);
+    QALU(qftReg)->CMULModNOut(5, 125U, 0, 8, 8, controls);
     REQUIRE_THAT(qftReg, HasProbability(0, 16, 65 | (75 << 8)));
 
     qftReg->SetPermutation(126 | (1 << 16));
-    QALU(qftReg)->CMULModNOut(5, 125U, 0, 8, 8, controls, 1);
+    QALU(qftReg)->CMULModNOut(5, 125U, 0, 8, 8, controls);
     REQUIRE_THAT(qftReg, HasProbability(0, 16, 126 | (5 << 8)));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_cimulmodnout")
 {
-    bitLenInt controls[1] = { 16 };
+    const std::vector<bitLenInt> controls{ 16 };
 
     qftReg->SetPermutation(1);
-    QALU(qftReg)->CMULModNOut(2, 256U, 0, 8, 8, NULL, 0);
-    QALU(qftReg)->CIMULModNOut(2, 256U, 0, 8, 8, NULL, 0);
+    QALU(qftReg)->CMULModNOut(2, 256U, 0, 8, 8, std::vector<bitLenInt>());
+    QALU(qftReg)->CIMULModNOut(2, 256U, 0, 8, 8, std::vector<bitLenInt>());
     REQUIRE_THAT(qftReg, HasProbability(0, 16, 1));
 
     qftReg->SetPermutation(3 | (1 << 16));
-    QALU(qftReg)->CMULModNOut(3, 256U, 0, 8, 8, controls, 1);
-    QALU(qftReg)->CIMULModNOut(3, 256U, 0, 8, 8, controls, 1);
+    QALU(qftReg)->CMULModNOut(3, 256U, 0, 8, 8, controls);
+    QALU(qftReg)->CIMULModNOut(3, 256U, 0, 8, 8, controls);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, 3 | (1 << 16)));
 
     qftReg->SetPermutation(65 | (1 << 16));
-    QALU(qftReg)->CMULModNOut(5, 125U, 0, 8, 8, controls, 1);
-    QALU(qftReg)->CIMULModNOut(5, 125U, 0, 8, 8, controls, 1);
+    QALU(qftReg)->CMULModNOut(5, 125U, 0, 8, 8, controls);
+    QALU(qftReg)->CIMULModNOut(5, 125U, 0, 8, 8, controls);
     REQUIRE_THAT(qftReg, HasProbability(0, 16, 65));
 
     qftReg->SetPermutation(126 | (1 << 16));
-    QALU(qftReg)->CMULModNOut(5, 125U, 0, 8, 8, controls, 1);
-    QALU(qftReg)->CIMULModNOut(5, 125U, 0, 8, 8, controls, 1);
+    QALU(qftReg)->CMULModNOut(5, 125U, 0, 8, 8, controls);
+    QALU(qftReg)->CIMULModNOut(5, 125U, 0, 8, 8, controls);
     REQUIRE_THAT(qftReg, HasProbability(0, 16, 126));
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_cpowmodnout", "[travis_xfail]")
 {
-    bitLenInt controls[1] = { 16 };
+    const std::vector<bitLenInt> controls{ 16 };
 
     qftReg->SetPermutation(1);
-    QALU(qftReg)->CPOWModNOut(2, 256U, 0, 8, 8, NULL, 0);
+    QALU(qftReg)->CPOWModNOut(2, 256U, 0, 8, 8, std::vector<bitLenInt>());
     REQUIRE_THAT(qftReg, HasProbability(0, 16, 1 | (2 << 8)));
 
     qftReg->SetPermutation(3 | (1 << 16));
-    QALU(qftReg)->CPOWModNOut(3, 256U, 0, 8, 8, controls, 1);
+    QALU(qftReg)->CPOWModNOut(3, 256U, 0, 8, 8, controls);
     REQUIRE_THAT(qftReg, HasProbability(0, 16, 3 | (27 << 8)));
 
     qftReg->SetPermutation(3);
     qftReg->H(16);
-    QALU(qftReg)->CPOWModNOut(3, 256U, 0, 8, 8, controls, 1);
+    QALU(qftReg)->CPOWModNOut(3, 256U, 0, 8, 8, controls);
     REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(3));
     REQUIRE_FLOAT(ONE_R1_F / 2, (real1_f)qftReg->ProbAll(3 | (27 << 8) | (1 << 16)));
 }
@@ -4855,15 +4854,15 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qfusion_controlled")
         return;
     }
 
-    bitLenInt controls[2] = { 1, 2 };
+    const std::vector<bitLenInt> controls{ 1, 2 };
     real1 angles[4] = { (real1)3.0f, (real1)0.8f, (real1)1.2f, (real1)0.7f };
 
     qftReg = CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType }, 3, 0, rng);
     qftReg->SetPermutation(2);
     QInterfacePtr qftReg2 = qftReg->Clone();
 
-    qftReg->UniformlyControlledRY(controls, 2, 0, angles);
-    qftReg2->QInterface::UniformlyControlledRY(controls, 2, 0, angles);
+    qftReg->UniformlyControlledRY(controls, 0, angles);
+    qftReg2->QInterface::UniformlyControlledRY(controls, 0, angles);
 
     complex a, b;
     for (bitCapInt i = 0; i < 8; i++) {
@@ -4884,14 +4883,14 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qneuron")
 
     qftReg->Dispose(0, qftReg->GetQubitCount() - (InputCount + OutputCount));
 
-    bitLenInt inputIndices[InputCount];
+    std::vector<bitLenInt> inputIndices(InputCount);
     for (bitLenInt i = 0; i < InputCount; i++) {
         inputIndices[i] = i;
     }
 
     std::vector<QNeuronPtr> outputLayer;
     for (bitLenInt i = 0; i < OutputCount; i++) {
-        outputLayer.push_back(std::make_shared<QNeuron>(qftReg, inputIndices, InputCount, InputCount + i));
+        outputLayer.push_back(std::make_shared<QNeuron>(qftReg, inputIndices, InputCount + i));
     }
 
     // Train the network to associate powers of 2 with their log2()
@@ -4919,14 +4918,14 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_qneuron")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_bell_m")
 {
-    bitCapInt qPowers[2] = { 1, 2 };
+    const std::vector<bitCapInt> qPowers{ 1, 2 };
     const std::set<bitCapInt> possibleResults = { 0, 3 };
 
     qftReg->SetPermutation(0);
     qftReg->H(0, 2);
     qftReg->CZ(0, 1);
     qftReg->H(0);
-    std::map<bitCapInt, int> results = qftReg->MultiShotMeasureMask(qPowers, 2U, 1000);
+    std::map<bitCapInt, int> results = qftReg->MultiShotMeasureMask(qPowers, 1000);
     std::map<bitCapInt, int>::iterator it = results.begin();
     while (it != results.end()) {
         REQUIRE(possibleResults.find(it->first) != possibleResults.end());
@@ -4937,7 +4936,7 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_bell_m")
     qftReg->H(0, 2);
     qftReg->CZ(0, 1);
     qftReg->H(1);
-    results = qftReg->MultiShotMeasureMask(qPowers, 2U, 1000);
+    results = qftReg->MultiShotMeasureMask(qPowers, 1000);
     it = results.begin();
     while (it != results.end()) {
         REQUIRE(possibleResults.find(it->first) != possibleResults.end());
@@ -5056,8 +5055,8 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_h_cnot_rand")
     REQUIRE_FLOAT((real1_f)norm(state[2]), ZERO_R1_F);
     REQUIRE_FLOAT((real1_f)norm(state[3]), ONE_R1_F / 2);
 
-    bitCapInt qPowers[2] = { 1, 2 };
-    std::map<bitCapInt, int> results = qftReg->MultiShotMeasureMask(qPowers, 2U, 1000);
+    const std::vector<bitCapInt> qPowers{ 1, 2 };
+    std::map<bitCapInt, int> results = qftReg->MultiShotMeasureMask(qPowers, 1000);
 
     REQUIRE(results.find(1) == results.end());
     REQUIRE(results.find(2) == results.end());

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -243,7 +243,7 @@ TEST_CASE("test_qengine_cpu_par_for_mask")
     std::atomic_int calls;
 
     const std::vector<bitCapIntOcl> skipArray{ 0x4, 0x100 }; // Skip bits 0b100000100
-    int NUM_SKIP = sizeof(skipArray) / sizeof(skipArray[0]);
+    int NUM_SKIP = skipArray.size();
 
     calls.store(0);
 


### PR DESCRIPTION
Qrack v8 makes two major changes to the API:
- Already merged in v7, qubit index parameters are checked for validity against simulators' allocated qubit bounds, to prevent OpenCL segmentation fault errors from explicitly invalid arguments.
- The content of _this_ PR is to replace the public API parameter pattern "pointer, pointerLength" with `std::vector`.

After 5 years of holding out for the more C-like version of the interface, there's very little to be said in favor of "pointer, pointerLength" over `std::vector`, which effectively enforces bounds safety. To use a contiguous subset of a `std::vector` from user code space, one can still use the appropriate iterator-based `std::vector` constructor. This probably requires the system to create a copy of the subset, but _at most_ this is likely fewer than 50 elements copied, typically more like 1 or 2 elements. The benefits of bounds-enforcement have been assessed to be _far_ more important than the additional execution time overhead, if that overhead can even be detected.

I had loosely planned for v8 to shape up by end of calendar year, but I suspect that not much damage will be done by merging sooner, particular since the v7 commit history is obviously still available. The XACC plugin update is also ready-to-go, right here, with plans to open a PR for it once Qrack v8 is merged in the Qrack repository:

https://github.com/WrathfulSpatula/xacc/tree/qrack_8_api

**If you need support in converting your user code to API v8, please don't hesitate to reach out with a GitHub issue on this repository!**