### PR TITLE
Replace !size() pattern with empty()

### DIFF
--- a/include/qcircuit.hpp
+++ b/include/qcircuit.hpp
@@ -124,7 +124,7 @@ struct QCircuitGate {
             return false;
         }
 
-        if (!controls.size() && !other->controls.size()) {
+        if (controls.empty() && other->controls.empty()) {
             return true;
         }
 
@@ -137,7 +137,7 @@ struct QCircuitGate {
             }
 
             if (mc) {
-                return !controls.size() || !other->controls.size() ||
+                return controls.empty() || other->controls.empty() ||
                     (*(controls.begin()) == *(other->controls.begin()));
             }
         }
@@ -308,7 +308,7 @@ struct QCircuitGate {
             std::copy(out, out + 4U, p);
         }
 
-        if (!payloads.size()) {
+        if (payloads.empty()) {
             Clear();
             return;
         }
@@ -421,7 +421,7 @@ struct QCircuitGate {
      */
     bool IsClifford()
     {
-        if (!payloads.size()) {
+        if (payloads.empty()) {
             // Swap gate is Clifford
             return true;
         }
@@ -430,7 +430,7 @@ struct QCircuitGate {
             return false;
         }
 
-        if (!controls.size()) {
+        if (controls.empty()) {
             return __IS_CLIFFORD(payloads[ZERO_BCI].get());
         }
 

--- a/include/qengine_cuda.hpp
+++ b/include/qengine_cuda.hpp
@@ -445,7 +445,7 @@ public:
     ;
     void UpdateRunningNorm(real1_f norm_thresh = REAL1_DEFAULT_ARG);
     void Finish() { clFinish(); };
-    bool isFinished() { return !wait_queue_items.size(); };
+    bool isFinished() { return wait_queue_items.empty(); };
 
     QInterfacePtr Clone();
 

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -341,7 +341,7 @@ public:
         if (true) {
             std::lock_guard<std::mutex> lock(queue_mutex);
             checkCallbackError();
-            isBase = !wait_queue_items.size();
+            isBase = wait_queue_items.empty();
             wait_queue_items.push_back(item);
         }
 
@@ -462,7 +462,7 @@ public:
     ;
     void UpdateRunningNorm(real1_f norm_thresh = REAL1_DEFAULT_ARG);
     void Finish() { clFinish(); };
-    bool isFinished() { return !wait_queue_items.size(); };
+    bool isFinished() { return wait_queue_items.empty(); };
 
     QInterfacePtr Clone();
 

--- a/include/qfactory.hpp
+++ b/include/qfactory.hpp
@@ -295,7 +295,7 @@ QInterfacePtr CreateArrangedLayers(bool md, bool sd, bool sh, bool bdt, bool pg,
     // (...then reverse:)
     std::reverse(simulatorType.begin(), simulatorType.end());
 
-    if (!simulatorType.size()) {
+    if (simulatorType.empty()) {
 #if ENABLE_OPENCL || ENABLE_CUDA
         if (hy && isOcl) {
             simulatorType.push_back(QINTERFACE_HYBRID);

--- a/include/qneuron.hpp
+++ b/include/qneuron.hpp
@@ -150,7 +150,7 @@ public:
             qReg->RY((real1_f)(PI_R1 / 2), outputIndex);
         }
 
-        if (!inputIndices.size()) {
+        if (inputIndices.empty()) {
             // If there are no controls, this "neuron" is actually just a bias.
             switch (activationFn) {
             case ReLU:
@@ -204,7 +204,7 @@ public:
     /** "Uncompute" the Predict() method */
     real1_f Unpredict(bool expected = true)
     {
-        if (!inputIndices.size()) {
+        if (inputIndices.empty()) {
             // If there are no controls, this "neuron" is actually just a bias.
             switch (activationFn) {
             case ReLU:

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -170,7 +170,7 @@ protected:
             fn(sample, shot);
 
             rng.erase(rng.begin() + shot);
-            if (!rng.size()) {
+            if (rng.empty()) {
                 break;
             }
         }

--- a/include/qtensornetwork.hpp
+++ b/include/qtensornetwork.hpp
@@ -107,7 +107,7 @@ protected:
 
     template <typename Fn> void RunAsAmplitudes(Fn fn, const std::set<bitLenInt>& qubits = std::set<bitLenInt>())
     {
-        if (!qubits.size()) {
+        if (qubits.empty()) {
             MakeLayerStack();
             return fn(layerStack);
         }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -59,8 +59,9 @@ public:
         bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
         real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devIDs = {}, bitLenInt qubitThreshold = 0U,
         real1_f separation_thresh = FP_NORM_EPSILON_F)
-        : QUnit({ QINTERFACE_STABILIZER_HYBRID }, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase, useHostMem,
-              deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, devIDs, qubitThreshold, separation_thresh)
+        : QUnit({ QINTERFACE_STABILIZER_HYBRID }, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase,
+              useHostMem, deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, devIDs, qubitThreshold,
+              separation_thresh)
     {
     }
 

--- a/include/qunitclifford.hpp
+++ b/include/qunitclifford.hpp
@@ -540,7 +540,7 @@ public:
     }
     void MCPhase(const std::vector<bitLenInt>& controls, complex topLeft, complex bottomRight, bitLenInt t)
     {
-        if (!controls.size()) {
+        if (controls.empty()) {
             Phase(topLeft, bottomRight, t);
             return;
         }
@@ -554,7 +554,7 @@ public:
     }
     void MACPhase(const std::vector<bitLenInt>& controls, complex topLeft, complex bottomRight, bitLenInt t)
     {
-        if (!controls.size()) {
+        if (controls.empty()) {
             Phase(topLeft, bottomRight, t);
             return;
         }
@@ -568,7 +568,7 @@ public:
     }
     void MCInvert(const std::vector<bitLenInt>& controls, complex topRight, complex bottomLeft, bitLenInt t)
     {
-        if (!controls.size()) {
+        if (controls.empty()) {
             Invert(topRight, bottomLeft, t);
             return;
         }
@@ -582,7 +582,7 @@ public:
     }
     void MACInvert(const std::vector<bitLenInt>& controls, complex topRight, complex bottomLeft, bitLenInt t)
     {
-        if (!controls.size()) {
+        if (controls.empty()) {
             Invert(topRight, bottomLeft, t);
             return;
         }
@@ -596,7 +596,7 @@ public:
     }
     void MCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt t)
     {
-        if (!controls.size()) {
+        if (controls.empty()) {
             Mtrx(mtrx, t);
             return;
         }
@@ -609,7 +609,7 @@ public:
     }
     void MACMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt t)
     {
-        if (!controls.size()) {
+        if (controls.empty()) {
             Mtrx(mtrx, t);
             return;
         }

--- a/include/statevector.hpp
+++ b/include/statevector.hpp
@@ -439,14 +439,14 @@ public:
         }
 
         for (int64_t i = (int64_t)(toRet.size() - 1U); i >= 0; i--) {
-            if (!toRet[i].size()) {
+            if (toRet[i].empty()) {
                 toRetIt = toRet.begin();
                 std::advance(toRetIt, i);
                 toRet.erase(toRetIt);
             }
         }
 
-        if (!toRet.size()) {
+        if (toRet.empty()) {
             return {};
         }
 
@@ -518,14 +518,14 @@ public:
         }
 
         for (int64_t i = (int64_t)(toRet.size() - 1U); i >= 0; i--) {
-            if (!toRet[i].size()) {
+            if (toRet[i].empty()) {
                 toRetIt = toRet.begin();
                 std::advance(toRetIt, i);
                 toRet.erase(toRetIt);
             }
         }
 
-        if (!toRet.size()) {
+        if (toRet.empty()) {
             return {};
         }
 

--- a/src/common/dispatchqueue.cpp
+++ b/src/common/dispatchqueue.cpp
@@ -107,7 +107,7 @@ void DispatchQueue::dispatch_thread_handler(void)
 
         lock.lock();
 
-        if (!q_.size()) {
+        if (q_.empty()) {
             isFinished_ = true;
             cvFinished_.notify_all();
         }

--- a/src/common/functions.cpp
+++ b/src/common/functions.cpp
@@ -255,7 +255,7 @@ bool isOverflowSub(
 
 bitCapInt pushApartBits(const bitCapInt& perm, const std::vector<bitCapInt>& skipPowers)
 {
-    if (!skipPowers.size()) {
+    if (skipPowers.empty()) {
         return perm;
     }
 

--- a/src/common/oclengine.cpp
+++ b/src/common/oclengine.cpp
@@ -293,7 +293,7 @@ InitOClResult OCLEngine::InitOCL(
 
     cl::Platform::get(&all_platforms);
 
-    if (!all_platforms.size()) {
+    if (all_platforms.empty()) {
         std::cout << " No platforms found. Check OpenCL installation!\n";
         return InitOClResult();
     }
@@ -346,7 +346,7 @@ InitOClResult OCLEngine::InitOCL(
         }
         all_devices_is_cpu.insert(all_devices_is_cpu.end(), cpu_to_insert.begin(), cpu_to_insert.end());
     }
-    if (!all_devices.size()) {
+    if (all_devices.empty()) {
         std::cout << " No devices found. Check OpenCL installation!\n";
         return InitOClResult();
     }

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -662,7 +662,7 @@ MICROSOFT_QUANTUM_DECL uintq init_count_type(_In_ uintq q, _In_ bool tn, _In_ bo
     // (...then reverse:)
     std::reverse(simulatorType.begin(), simulatorType.end());
 
-    if (!simulatorType.size()) {
+    if (simulatorType.empty()) {
 #if ENABLE_OPENCL
         if (hy && isOcl) {
             simulatorType.push_back(QINTERFACE_HYBRID);
@@ -1888,7 +1888,7 @@ MICROSOFT_QUANTUM_DECL void Exp(
     removeIdentities(&bVec, &qVec);
 
     try {
-        if (!bVec.size()) {
+        if (bVec.empty()) {
             RHelper(sid, PauliI, -2. * phi, someQubit);
         } else if (bVec.size() == 1U) {
             RHelper(sid, bVec.front(), -2. * phi, qVec.front());
@@ -1926,7 +1926,7 @@ MICROSOFT_QUANTUM_DECL void MCExp(_In_ uintq sid, _In_ uintq n, _In_reads_(n) in
     removeIdentities(&bVec, &qVec);
 
     try {
-        if (!bVec.size()) {
+        if (bVec.empty()) {
             MCRHelper(sid, PauliI, -2. * phi, nc, cs, someQubit);
         } else if (bVec.size() == 1U) {
             MCRHelper(sid, bVec.front(), -2. * phi, nc, cs, qVec.front());
@@ -3370,7 +3370,7 @@ uintq _init_qcircuit_copy(uintq cid, bool isInverse, std::set<bitLenInt> q)
         }
     }
 
-    QCircuitPtr nCircuit = isInverse ? circuit->Inverse() : (q.size() ? circuit->PastLightCone(q) : circuit->Clone());
+    QCircuitPtr nCircuit = isInverse ? circuit->Inverse() : (q.empty() ? circuit->Clone() : circuit->PastLightCone(q));
 
     if (ncid == circuits.size()) {
         circuitReservations.push_back(true);

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -44,7 +44,7 @@ void QBdt::Init()
         bdtStride = 1U;
     }
 
-    if (!engines.size()) {
+    if (engines.empty()) {
         engines.push_back(QINTERFACE_OPTIMAL_BASE);
     }
     QInterfaceEngine rootEngine = engines[0U];
@@ -761,7 +761,7 @@ void QBdt::Mtrx(const complex* mtrx, bitLenInt target)
 
 void QBdt::MCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         Mtrx(mtrx, target);
     } else if (IS_NORM_0(mtrx[1U]) && IS_NORM_0(mtrx[2U])) {
         MCPhase(controls, mtrx[0U], mtrx[3U], target);
@@ -777,7 +777,7 @@ void QBdt::MCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, b
 void QBdt::MACMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
 {
 
-    if (!controls.size()) {
+    if (controls.empty()) {
         Mtrx(mtrx, target);
     } else if (IS_NORM_0(mtrx[1U]) && IS_NORM_0(mtrx[2U])) {
         MACPhase(controls, mtrx[0U], mtrx[3U], target);
@@ -792,7 +792,7 @@ void QBdt::MACMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, 
 
 void QBdt::MCPhase(const std::vector<bitLenInt>& controls, complex topLeft, complex bottomRight, bitLenInt target)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         Phase(topLeft, bottomRight, target);
         return;
     }
@@ -820,7 +820,7 @@ void QBdt::MCPhase(const std::vector<bitLenInt>& controls, complex topLeft, comp
 
 void QBdt::MCInvert(const std::vector<bitLenInt>& controls, complex topRight, complex bottomLeft, bitLenInt target)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         Invert(topRight, bottomLeft, target);
         return;
     }

--- a/src/qcircuit.cpp
+++ b/src/qcircuit.cpp
@@ -196,7 +196,7 @@ void QCircuit::Run(QInterfacePtr qsim)
     for (const QCircuitGatePtr& gate : nGates) {
         const bitLenInt& t = gate->target;
 
-        if (!gate->controls.size()) {
+        if (gate->controls.empty()) {
             qsim->Mtrx(gate->payloads[ZERO_BCI].get(), t);
 
             continue;
@@ -204,7 +204,7 @@ void QCircuit::Run(QInterfacePtr qsim)
 
         std::vector<bitLenInt> controls = gate->GetControlsVector();
 
-        if (!gate->payloads.size()) {
+        if (gate->payloads.empty()) {
             qsim->Swap(controls[0U], t);
 
             continue;

--- a/src/qengine/arithmetic.cpp
+++ b/src/qengine/arithmetic.cpp
@@ -112,7 +112,7 @@ void QEngineCPU::CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, c
 {
     CHECK_ZERO_SKIP();
 
-    if (!controls.size()) {
+    if (controls.empty()) {
         INC(toAdd, inOutStart, length);
         return;
     }
@@ -529,7 +529,7 @@ void QEngineCPU::CMULDIV(const IOFn& inFn, const IOFn& outFn, const bitCapInt& t
 void QEngineCPU::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
     const std::vector<bitLenInt>& controls)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         MUL(toMul, inOutStart, carryStart, length);
         return;
     }
@@ -552,7 +552,7 @@ void QEngineCPU::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStar
 void QEngineCPU::CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
     const std::vector<bitLenInt>& controls)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         DIV(toDiv, inOutStart, carryStart, length);
         return;
     }
@@ -729,7 +729,7 @@ void QEngineCPU::CMULModNOut(bitCapInt toMod, bitCapInt modN, bitLenInt inStart,
 void QEngineCPU::CIMULModNOut(bitCapInt toMod, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
     const std::vector<bitLenInt>& controls)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         IMULModNOut(toMod, modN, inStart, outStart, length);
         return;
     }
@@ -742,7 +742,7 @@ void QEngineCPU::CIMULModNOut(bitCapInt toMod, bitCapInt modN, bitLenInt inStart
 void QEngineCPU::CPOWModNOut(bitCapInt toMod, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
     const std::vector<bitLenInt>& controls)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         POWModNOut(toMod, modN, inStart, outStart, length);
         return;
     }

--- a/src/qengine/cuda.cu
+++ b/src/qengine/cuda.cu
@@ -351,7 +351,7 @@ void QEngineCUDA::PopQueue()
         }
     }
 
-    if (!wait_queue_items.size()) {
+    if (wait_queue_items.empty()) {
         return;
     }
 
@@ -374,7 +374,7 @@ void QEngineCUDA::DispatchQueue()
     if (true) {
         std::lock_guard<std::mutex> lock(queue_mutex);
 
-        if (!wait_queue_items.size()) {
+        if (wait_queue_items.empty()) {
             return;
         }
 
@@ -1066,7 +1066,7 @@ void QEngineCUDA::UniformlyControlledSingleBit(const std::vector<bitLenInt>& con
     CHECK_ZERO_SKIP();
 
     // If there are no controls, the base case should be the non-controlled single bit gate.
-    if (!controls.size()) {
+    if (controls.empty()) {
         Mtrx(mtrxs + ((bitCapIntOcl)mtrxSkipValueMask << 2U), qubitIndex);
         return;
     }
@@ -1156,7 +1156,7 @@ void QEngineCUDA::UniformParityRZ(bitCapInt mask, real1_f angle)
 
 void QEngineCUDA::CUniformParityRZ(const std::vector<bitLenInt>& controls, bitCapInt mask, real1_f angle)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         UniformParityRZ(mask, angle);
         return;
     }
@@ -1902,7 +1902,7 @@ real1_f QEngineCUDA::ExpectationBitsAll(const std::vector<bitLenInt>& bits, bitC
         return Prob(bits[0]);
     }
 
-    if (!stateBuffer || !bits.size()) {
+    if (!stateBuffer || bits.empty()) {
         return ZERO_R1_F;
     }
 
@@ -2121,7 +2121,7 @@ void QEngineCUDA::INC(bitCapInt toAdd, bitLenInt start, bitLenInt length)
 
 void QEngineCUDA::CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const std::vector<bitLenInt>& controls)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         INC(toAdd, inOutStart, length);
         return;
     }
@@ -2446,7 +2446,7 @@ void QEngineCUDA::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carrySta
 {
     CHECK_ZERO_SKIP();
 
-    if (!controls.size()) {
+    if (controls.empty()) {
         MUL(toMul, inOutStart, carryStart, length);
         return;
     }
@@ -2466,7 +2466,7 @@ void QEngineCUDA::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carrySta
 void QEngineCUDA::CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
     const std::vector<bitLenInt>& controls)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         DIV(toDiv, inOutStart, carryStart, length);
         return;
     }
@@ -2488,7 +2488,7 @@ void QEngineCUDA::CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart
 {
     CHECK_ZERO_SKIP();
 
-    if (!controls.size()) {
+    if (controls.empty()) {
         MULModNOut(toMul, modN, inStart, outStart, length);
         return;
     }
@@ -2507,7 +2507,7 @@ void QEngineCUDA::CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart
 void QEngineCUDA::CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
     const std::vector<bitLenInt>& controls)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         IMULModNOut(toMul, modN, inStart, outStart, length);
         return;
     }
@@ -2527,7 +2527,7 @@ void QEngineCUDA::CPOWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart,
 {
     CHECK_ZERO_SKIP();
 
-    if (!controls.size()) {
+    if (controls.empty()) {
         POWModNOut(base, modN, inStart, outStart, length);
         return;
     }

--- a/src/qengine/opencl.cpp
+++ b/src/qengine/opencl.cpp
@@ -398,7 +398,7 @@ EventVecPtr QEngineOCL::ResetWaitEvents(bool waitQueue)
     if (waitVec->size()) {
         wait_refs.emplace_back(waitVec);
     }
-    return wait_refs.size() ? wait_refs.back() : std::make_shared<EventVec>();
+    return wait_refs.empty() ? std::make_shared<EventVec>() : wait_refs.back();
 }
 
 void QEngineOCL::WaitCall(
@@ -425,7 +425,7 @@ void QEngineOCL::PopQueue(bool isDispatch)
             }
         }
 
-        if (!wait_queue_items.size()) {
+        if (wait_queue_items.empty()) {
             return;
         }
         SubtractAlloc(wait_queue_items.front().deallocSize);
@@ -450,7 +450,7 @@ void QEngineOCL::DispatchQueue()
     if (true) {
         std::lock_guard<std::mutex> lock(queue_mutex);
 
-        if (!wait_queue_items.size()) {
+        if (wait_queue_items.empty()) {
             return;
         }
 
@@ -465,7 +465,7 @@ void QEngineOCL::DispatchQueue()
             }
 
             wait_queue_items.pop_front();
-            if (!wait_queue_items.size()) {
+            if (wait_queue_items.empty()) {
                 return;
             }
             item = wait_queue_items.front();
@@ -1032,7 +1032,7 @@ void QEngineOCL::UniformlyControlledSingleBit(const std::vector<bitLenInt>& cont
     CHECK_ZERO_SKIP();
 
     // If there are no controls, the base case should be the non-controlled single bit gate.
-    if (!controls.size()) {
+    if (controls.empty()) {
         Mtrx(mtrxs + ((bitCapIntOcl)mtrxSkipValueMask << 2U), qubitIndex);
         return;
     }
@@ -1131,7 +1131,7 @@ void QEngineOCL::UniformParityRZ(bitCapInt mask, real1_f angle)
 
 void QEngineOCL::CUniformParityRZ(const std::vector<bitLenInt>& controls, bitCapInt mask, real1_f angle)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         UniformParityRZ(mask, angle);
         return;
     }
@@ -1945,7 +1945,7 @@ real1_f QEngineOCL::ExpectationBitsAll(const std::vector<bitLenInt>& bits, bitCa
         return Prob(bits[0]);
     }
 
-    if (!stateBuffer || !bits.size()) {
+    if (!stateBuffer || bits.empty()) {
         return ZERO_R1_F;
     }
 
@@ -2167,7 +2167,7 @@ void QEngineOCL::INC(bitCapInt toAdd, bitLenInt start, bitLenInt length)
 
 void QEngineOCL::CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const std::vector<bitLenInt>& controls)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         INC(toAdd, inOutStart, length);
         return;
     }
@@ -2500,7 +2500,7 @@ void QEngineOCL::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStar
 {
     CHECK_ZERO_SKIP();
 
-    if (!controls.size()) {
+    if (controls.empty()) {
         MUL(toMul, inOutStart, carryStart, length);
         return;
     }
@@ -2520,7 +2520,7 @@ void QEngineOCL::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStar
 void QEngineOCL::CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
     const std::vector<bitLenInt>& controls)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         DIV(toDiv, inOutStart, carryStart, length);
         return;
     }
@@ -2543,7 +2543,7 @@ void QEngineOCL::CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart,
 {
     CHECK_ZERO_SKIP();
 
-    if (!controls.size()) {
+    if (controls.empty()) {
         MULModNOut(toMul, modN, inStart, outStart, length);
         return;
     }
@@ -2562,7 +2562,7 @@ void QEngineOCL::CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart,
 void QEngineOCL::CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
     const std::vector<bitLenInt>& controls)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         IMULModNOut(toMul, modN, inStart, outStart, length);
         return;
     }
@@ -2582,7 +2582,7 @@ void QEngineOCL::CPOWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, 
 {
     CHECK_ZERO_SKIP();
 
-    if (!controls.size()) {
+    if (controls.empty()) {
         POWModNOut(base, modN, inStart, outStart, length);
         return;
     }

--- a/src/qengine/qengine.cpp
+++ b/src/qengine/qengine.cpp
@@ -28,7 +28,7 @@ void QEngine::Mtrx(complex const* mtrx, bitLenInt qubit)
 
 void QEngine::EitherMtrx(const std::vector<bitLenInt>& controls, complex const* mtrx, bitLenInt target, bool isAnti)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         Mtrx(mtrx, target);
         return;
     }
@@ -51,7 +51,7 @@ void QEngine::EitherMtrx(const std::vector<bitLenInt>& controls, complex const* 
 void QEngine::UCMtrx(
     const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target, bitCapInt controlPerm)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         Mtrx(mtrx, target);
         return;
     }
@@ -124,7 +124,7 @@ bitCapInt QEngine::ForceM(const std::vector<bitLenInt>& bits, const std::vector<
 
     // Single bit operations are better optimized for this special case:
     if (bits.size() == 1U) {
-        if (ForceM(bits[0U], values.size() ? values[0U] : false, false, doApply)) {
+        if (ForceM(bits[0U], values.empty() ? false : values[0U], false, doApply)) {
             return pow2(bits[0U]);
         } else {
             return ZERO_BCI;
@@ -213,7 +213,7 @@ bitCapInt QEngine::ForceM(const std::vector<bitLenInt>& bits, const std::vector<
 
 void QEngine::CSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         Swap(qubit1, qubit2);
         return;
     }
@@ -242,7 +242,7 @@ void QEngine::CSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bi
 
 void QEngine::AntiCSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         Swap(qubit1, qubit2);
         return;
     }
@@ -268,7 +268,7 @@ void QEngine::AntiCSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1
 
 void QEngine::CSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         SqrtSwap(qubit1, qubit2);
         return;
     }
@@ -298,7 +298,7 @@ void QEngine::CSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1
 
 void QEngine::AntiCSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         SqrtSwap(qubit1, qubit2);
         return;
     }
@@ -325,7 +325,7 @@ void QEngine::AntiCSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qu
 
 void QEngine::CISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         ISqrtSwap(qubit1, qubit2);
         return;
     }
@@ -355,7 +355,7 @@ void QEngine::CISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit
 
 void QEngine::AntiCISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         ISqrtSwap(qubit1, qubit2);
         return;
     }

--- a/src/qengine/state.cpp
+++ b/src/qengine/state.cpp
@@ -779,7 +779,7 @@ void QEngineCPU::UniformlyControlledSingleBit(const std::vector<bitLenInt>& cont
     CHECK_ZERO_SKIP();
 
     // If there are no controls, the base case should be the non-controlled single bit gate.
-    if (!controls.size()) {
+    if (controls.empty()) {
         Mtrx(mtrxs + ((bitCapIntOcl)mtrxSkipValueMask * 4U), qubitIndex);
         return;
     }
@@ -914,7 +914,7 @@ void QEngineCPU::UniformParityRZ(bitCapInt mask, real1_f angle)
 
 void QEngineCPU::CUniformParityRZ(const std::vector<bitLenInt>& cControls, bitCapInt mask, real1_f angle)
 {
-    if (!cControls.size()) {
+    if (cControls.empty()) {
         return UniformParityRZ(mask, angle);
     }
 

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -88,7 +88,7 @@ QPager::QPager(QEnginePtr enginePtr, std::vector<QInterfaceEngine> eng, bitLenIn
 
 void QPager::Init()
 {
-    if (!engines.size()) {
+    if (engines.empty()) {
 #if ENABLE_OPENCL || ENABLE_CUDA
         engines.push_back(QRACK_GPU_SINGLETON.GetDeviceCount() ? QRACK_GPU_ENGINE : QINTERFACE_CPU);
 #else
@@ -264,7 +264,7 @@ void QPager::Init()
     }
 #endif
 
-    if (!deviceIDs.size()) {
+    if (deviceIDs.empty()) {
 #if ENABLE_OPENCL || ENABLE_CUDA
         const size_t devCount = QRACK_GPU_SINGLETON.GetDeviceCount();
         if (devCount < 2U) {
@@ -288,7 +288,7 @@ void QPager::Init()
         deviceIDs.push_back(devID);
 #endif
     }
-    if (!devicesHostPointer.size()) {
+    if (devicesHostPointer.empty()) {
         devicesHostPointer.push_back(useHostRam);
     }
 }
@@ -991,7 +991,7 @@ void QPager::ApplySingleEither(bool isInvert, complex top, complex bottom, bitLe
 void QPager::ApplyEitherControlledSingleBit(
     bitCapInt controlPerm, const std::vector<bitLenInt>& controls, bitLenInt target, const complex* mtrx)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         Mtrx(mtrx, target);
         return;
     }
@@ -1028,7 +1028,7 @@ void QPager::ApplyEitherControlledSingleBit(
         engine->UCMtrx(intraControls, mtrx, lTarget, intraCtrlPerm);
     };
 
-    if (!metaControls.size()) {
+    if (metaControls.empty()) {
         SingleBitGate(target, sg, isSqiCtrl, isAnti);
     } else if (target < qpp) {
         SemiMetaControlled(metaCtrlPerm, metaControls, target, sg);
@@ -1198,7 +1198,7 @@ void QPager::POWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLe
 void QPager::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
     const std::vector<bitLenInt>& controls)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         MUL(toMul, inOutStart, carryStart, length);
         return;
     }
@@ -1210,7 +1210,7 @@ void QPager::CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, b
 void QPager::CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
     const std::vector<bitLenInt>& controls)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         DIV(toDiv, inOutStart, carryStart, length);
         return;
     }
@@ -1222,7 +1222,7 @@ void QPager::CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, b
 void QPager::CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
     const std::vector<bitLenInt>& controls)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         MULModNOut(toMul, modN, inStart, outStart, length);
         return;
     }
@@ -1234,7 +1234,7 @@ void QPager::CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bit
 void QPager::CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
     const std::vector<bitLenInt>& controls)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         IMULModNOut(toMul, modN, inStart, outStart, length);
         return;
     }
@@ -1246,7 +1246,7 @@ void QPager::CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bi
 void QPager::CPOWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
     const std::vector<bitLenInt>& controls)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         POWModNOut(base, modN, inStart, outStart, length);
         return;
     }

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -1998,7 +1998,7 @@ void QStabilizer::MCPhase(
         return;
     }
 
-    if (!controls.size()) {
+    if (controls.empty()) {
         Phase(topLeft, bottomRight, target);
         return;
     }
@@ -2065,7 +2065,7 @@ void QStabilizer::MACPhase(
         return;
     }
 
-    if (!controls.size()) {
+    if (controls.empty()) {
         Phase(topLeft, bottomRight, target);
         return;
     }
@@ -2128,7 +2128,7 @@ void QStabilizer::MACPhase(
 void QStabilizer::MCInvert(
     const std::vector<bitLenInt>& controls, complex topRight, complex bottomLeft, bitLenInt target)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         Invert(topRight, bottomLeft, target);
         return;
     }
@@ -2189,7 +2189,7 @@ void QStabilizer::MCInvert(
 void QStabilizer::MACInvert(
     const std::vector<bitLenInt>& controls, complex topRight, complex bottomLeft, bitLenInt target)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         Invert(topRight, bottomLeft, target);
         return;
     }

--- a/src/qstabilizerhybrid.cpp
+++ b/src/qstabilizerhybrid.cpp
@@ -825,7 +825,7 @@ complex QStabilizerHybrid::GetAmplitudeOrProb(bitCapInt perm, bool isProb)
             et.erase(et.begin() + i);
         }
     }
-    if (!et.size()) {
+    if (et.empty()) {
         et.push_back(QINTERFACE_OPTIMAL_BASE);
     }
     QEnginePtr aEngine = std::dynamic_pointer_cast<QEngine>(
@@ -941,7 +941,7 @@ void QStabilizerHybrid::CSwap(const std::vector<bitLenInt>& lControls, bitLenInt
         if (TrimControls(lControls, controls, false)) {
             return;
         }
-        if (!controls.size()) {
+        if (controls.empty()) {
             stabilizer->Swap(qubit1, qubit2);
             return;
         }
@@ -957,7 +957,7 @@ void QStabilizerHybrid::CSqrtSwap(const std::vector<bitLenInt>& lControls, bitLe
         if (TrimControls(lControls, controls, false)) {
             return;
         }
-        if (!controls.size()) {
+        if (controls.empty()) {
             QInterface::SqrtSwap(qubit1, qubit2);
             return;
         }
@@ -973,7 +973,7 @@ void QStabilizerHybrid::AntiCSqrtSwap(const std::vector<bitLenInt>& lControls, b
         if (TrimControls(lControls, controls, true)) {
             return;
         }
-        if (!controls.size()) {
+        if (controls.empty()) {
             QInterface::SqrtSwap(qubit1, qubit2);
             return;
         }
@@ -989,7 +989,7 @@ void QStabilizerHybrid::CISqrtSwap(const std::vector<bitLenInt>& lControls, bitL
         if (TrimControls(lControls, controls, false)) {
             return;
         }
-        if (!controls.size()) {
+        if (controls.empty()) {
             QInterface::ISqrtSwap(qubit1, qubit2);
             return;
         }
@@ -1005,7 +1005,7 @@ void QStabilizerHybrid::AntiCISqrtSwap(const std::vector<bitLenInt>& lControls, 
         if (TrimControls(lControls, controls, true)) {
             return;
         }
-        if (!controls.size()) {
+        if (controls.empty()) {
             QInterface::ISqrtSwap(qubit1, qubit2);
             return;
         }
@@ -1151,7 +1151,7 @@ void QStabilizerHybrid::MCMtrx(const std::vector<bitLenInt>& lControls, const co
         return;
     }
 
-    if (!controls.size()) {
+    if (controls.empty()) {
         Mtrx(mtrx, target);
         return;
     }
@@ -1177,7 +1177,7 @@ void QStabilizerHybrid::MCPhase(
         return;
     }
 
-    if (!controls.size()) {
+    if (controls.empty()) {
         Phase(topLeft, bottomRight, target);
         return;
     }
@@ -1226,7 +1226,7 @@ void QStabilizerHybrid::MCInvert(
         return;
     }
 
-    if (!controls.size()) {
+    if (controls.empty()) {
         Invert(topRight, bottomLeft, target);
         return;
     }
@@ -1278,7 +1278,7 @@ void QStabilizerHybrid::MACMtrx(const std::vector<bitLenInt>& lControls, const c
         return;
     }
 
-    if (!controls.size()) {
+    if (controls.empty()) {
         Mtrx(mtrx, target);
         return;
     }
@@ -1300,7 +1300,7 @@ void QStabilizerHybrid::MACPhase(
         return;
     }
 
-    if (!controls.size()) {
+    if (controls.empty()) {
         Phase(topLeft, bottomRight, target);
         return;
     }
@@ -1349,7 +1349,7 @@ void QStabilizerHybrid::MACInvert(
         return;
     }
 
-    if (!controls.size()) {
+    if (controls.empty()) {
         Invert(topRight, bottomLeft, target);
         return;
     }
@@ -1644,7 +1644,7 @@ void QStabilizerHybrid::UniformlyControlledSingleBit(
     stateMapCache.clear();
 
 #define ADD_SHOTS_PROB(m)                                                                                              \
-    if (!rng.size()) {                                                                                                 \
+    if (rng.empty()) {                                                                                                 \
         continue;                                                                                                      \
     }                                                                                                                  \
     ADD_SHOT_PROB(m)
@@ -1722,7 +1722,7 @@ std::map<bitCapInt, int> QStabilizerHybrid::MultiShotMeasureMask(const std::vect
             const real1 prob = futures[j].get();
             CHECK_SHOTS_IF_ANY(j + p, shotFunc);
         }
-        if (!rng.size()) {
+        if (rng.empty()) {
             break;
         }
     }
@@ -1812,7 +1812,7 @@ void QStabilizerHybrid::MultiShotMeasureMask(
             const real1 prob = futures[j].get();
             CHECK_SHOTS_IF_ANY(j + p, shotFunc);
         }
-        if (!rng.size()) {
+        if (rng.empty()) {
             break;
         }
     }

--- a/src/qtensornetwork.cpp
+++ b/src/qtensornetwork.cpp
@@ -54,7 +54,7 @@ QTensorNetwork::QTensorNetwork(std::vector<QInterfaceEngine> eng, bitLenInt qBit
 #endif
     isReactiveSeparate = (separabilityThreshold > FP_NORM_EPSILON_F);
 
-    if (!engines.size()) {
+    if (engines.empty()) {
 #if ENABLE_OPENCL
         engines.push_back((OCLEngine::Instance().GetDeviceCount() > 1) ? QINTERFACE_OPTIMAL_MULTI : QINTERFACE_OPTIMAL);
 #elif ENABLE_CUDA
@@ -138,7 +138,7 @@ void QTensorNetwork::MakeLayerStack(std::set<bitLenInt> qubits)
                     qubits.erase(m.first);
                 }
             }
-            if (!qubits.size()) {
+            if (qubits.empty()) {
                 QRACK_CONST complex pauliX[4]{ ZERO_CMPLX, ONE_CMPLX, ONE_CMPLX, ZERO_CMPLX };
                 c.push_back(std::make_shared<QCircuit>(true, isNearClifford));
                 for (const auto& m : measurements[j]) {
@@ -216,7 +216,7 @@ bool QTensorNetwork::ForceM(bitLenInt qubit, bool result, bool doForce, bool doA
         m.erase(qubit);
 
         // If the measurement layer is empty, telescope the layers.
-        if (!m.size()) {
+        if (m.empty()) {
             measurements.erase(measurements.begin() + layerId);
             const size_t prevLayerId = layerId + 1U;
             if (prevLayerId < circuit.size()) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -32,8 +32,8 @@
 #define IS_1_CMPLX(c) (norm(ONE_CMPLX - (c)) <= FP_NORM_EPSILON)
 #define SHARD_STATE(shard) ((2 * norm(shard.amp0)) < ONE_R1)
 #define QUEUED_PHASE(shard)                                                                                            \
-    ((shard.targetOfShards.size() != 0U) || (shard.controlsShards.size() != 0U) ||                                     \
-        (shard.antiTargetOfShards.size() != 0U) || (shard.antiControlsShards.size() != 0U))
+    (shard.targetOfShards.size() || shard.controlsShards.size() || shard.antiTargetOfShards.size() ||                  \
+        shard.antiControlsShards.size())
 #define CACHED_X(shard) ((shard.pauliBasis == PauliX) && !DIRTY(shard) && !QUEUED_PHASE(shard))
 #define CACHED_X_OR_Y(shard) ((shard.pauliBasis != PauliZ) && !DIRTY(shard) && !QUEUED_PHASE(shard))
 #define CACHED_Z(shard) ((shard.pauliBasis == PauliZ) && !DIRTY(shard) && !QUEUED_PHASE(shard))
@@ -79,7 +79,7 @@ QUnit::QUnit(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt i
     , deviceIDs(devList)
     , engines(eng)
 {
-    if (!engines.size()) {
+    if (engines.empty()) {
         engines.push_back(QINTERFACE_STABILIZER_HYBRID);
     }
 
@@ -1080,7 +1080,7 @@ void QUnit::PhaseParity(real1 radians, bitCapInt mask)
         eIndices.push_back(qIndices[i]);
     }
 
-    if (!eIndices.size()) {
+    if (eIndices.empty()) {
         if (flipResult) {
             Phase(phaseFac, phaseFac, 0U);
         } else {
@@ -1159,7 +1159,7 @@ real1_f QUnit::ProbParity(bitCapInt mask)
         bi_or_ip(&(units[shard.unit]), pow2(shard.mapped));
     }
 
-    if (!qIndices.size()) {
+    if (qIndices.empty()) {
         return (real1_f)oddChance;
     }
 
@@ -1212,7 +1212,7 @@ bool QUnit::ForceMParity(bitCapInt mask, bool result, bool doForce)
         eIndices.push_back(qIndices[i]);
     }
 
-    if (!eIndices.size()) {
+    if (eIndices.empty()) {
         return flipResult;
     }
 
@@ -1277,7 +1277,7 @@ void QUnit::CUniformParityRZ(const std::vector<bitLenInt>& cControls, bitCapInt 
         eIndices.push_back(qIndices[i]);
     }
 
-    if (!eIndices.size()) {
+    if (eIndices.empty()) {
         real1 cosine = (real1)cos(angle);
         real1 sine = (real1)sin(angle);
         complex phaseFac;
@@ -1286,7 +1286,7 @@ void QUnit::CUniformParityRZ(const std::vector<bitLenInt>& cControls, bitCapInt 
         } else {
             phaseFac = complex(cosine, -sine);
         }
-        if (!controls.size()) {
+        if (controls.empty()) {
             return Phase(phaseFac, phaseFac, 0U);
         } else {
             return MCPhase(controls, phaseFac, phaseFac, 0U);
@@ -1304,7 +1304,7 @@ void QUnit::CUniformParityRZ(const std::vector<bitLenInt>& cControls, bitCapInt 
             phaseFac = complex(cosine, sine);
             phaseFacAdj = complex(cosine, -sine);
         }
-        if (!controls.size()) {
+        if (controls.empty()) {
             return Phase(phaseFacAdj, phaseFac, eIndices[0U]);
         } else {
             return MCPhase(controls, phaseFacAdj, phaseFac, eIndices[0U]);
@@ -1322,7 +1322,7 @@ void QUnit::CUniformParityRZ(const std::vector<bitLenInt>& cControls, bitCapInt 
         bi_or_ip(&mappedMask, pow2(shards[eIndices[i]].mapped));
     }
 
-    if (!controls.size()) {
+    if (controls.empty()) {
         std::dynamic_pointer_cast<QParity>(unit)->UniformParityRZ(mappedMask, flipResult ? -angle : angle);
     } else {
         std::vector<bitLenInt*> ebits(controls.size());
@@ -1967,7 +1967,7 @@ void QUnit::UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls,
     const complex* mtrxs, const std::vector<bitCapInt>& mtrxSkipPowers, bitCapInt mtrxSkipValueMask)
 {
     // If there are no controls, this is equivalent to the single bit gate.
-    if (!controls.size()) {
+    if (controls.empty()) {
         Mtrx(mtrxs, qubitIndex);
         return;
     }
@@ -1993,7 +1993,7 @@ void QUnit::UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls,
     }
 
     // If all controls are in eigenstates, we can avoid entangling them.
-    if (!trimmedControls.size()) {
+    if (trimmedControls.empty()) {
         bitCapInt controlPerm = GetCachedPermutation(controls);
         complex mtrx[4U];
         std::copy(mtrxs + ((bitCapIntOcl)controlPerm << 2U), mtrxs + (((bitCapIntOcl)controlPerm + 1U) << 2U), mtrx);
@@ -2248,7 +2248,7 @@ void QUnit::ZBase(bitLenInt target)
     if (TrimControls(controls, controlVec, &_perm)) {                                                                  \
         return;                                                                                                        \
     }                                                                                                                  \
-    if (!controlVec.size()) {                                                                                          \
+    if (controlVec.empty()) {                                                                                          \
         bare;                                                                                                          \
         return;                                                                                                        \
     }                                                                                                                  \
@@ -2387,7 +2387,7 @@ void QUnit::UCPhase(const std::vector<bitLenInt>& lControls, complex topLeft, co
         return;
     }
 
-    if (!controlVec.size()) {
+    if (controlVec.empty()) {
         Phase(topLeft, bottomRight, target);
         return;
     }
@@ -2461,7 +2461,7 @@ void QUnit::UCInvert(const std::vector<bitLenInt>& lControls, complex topRight, 
         return;
     }
 
-    if (!controlVec.size()) {
+    if (controlVec.empty()) {
         Invert(topRight, bottomLeft, target);
         return;
     }
@@ -2581,7 +2581,7 @@ void QUnit::UCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, 
         return;
     }
 
-    if (!controlVec.size()) {
+    if (controlVec.empty()) {
         Mtrx(mtrx, target);
         return;
     }
@@ -2628,7 +2628,7 @@ bool QUnit::TrimControls(const std::vector<bitLenInt>& controls, std::vector<bit
     // If the controls start entirely separated from the targets, it's probably worth checking to see if the have
     // total or no probability of altering the targets, such that we can still keep them separate.
 
-    if (!controls.size()) {
+    if (controls.empty()) {
         // (If we were passed 0 controls, the target functions as a gate without controls.)
         return false;
     }
@@ -3014,7 +3014,7 @@ void QUnit::CINC(bitCapInt toMod, bitLenInt start, bitLenInt length, const std::
         return;
     }
 
-    if (!controlVec.size()) {
+    if (controlVec.empty()) {
         INC(toMod, start, length);
         return;
     }
@@ -3623,7 +3623,7 @@ void QUnit::CMUL(
         return;
     }
 
-    if (!controlVec.size()) {
+    if (controlVec.empty()) {
         MUL(toMod, start, carryStart, length);
         return;
     }
@@ -3653,7 +3653,7 @@ void QUnit::CDIV(
         return;
     }
 
-    if (!controlVec.size()) {
+    if (controlVec.empty()) {
         DIV(toMod, start, carryStart, length);
         return;
     }
@@ -3664,7 +3664,7 @@ void QUnit::CDIV(
 void QUnit::CPOWModNOut(bitCapInt toMod, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
     const std::vector<bitLenInt>& controls)
 {
-    if (!controls.size()) {
+    if (controls.empty()) {
         POWModNOut(toMod, modN, inStart, outStart, length);
         return;
     }

--- a/src/qunitmulti.cpp
+++ b/src/qunitmulti.cpp
@@ -69,7 +69,7 @@ QUnitMulti::QUnitMulti(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, b
     defaultDeviceID = (deviceID < 0) ? QRACK_GPU_SINGLETON.GetDefaultDeviceID() : (size_t)deviceID;
 
 #if ENABLE_ENV_VARS
-    if (!devList.size() && getenv("QRACK_QUNITMULTI_DEVICES")) {
+    if (devList.empty() && getenv("QRACK_QUNITMULTI_DEVICES")) {
         std::string devListStr = std::string(getenv("QRACK_QUNITMULTI_DEVICES"));
         devList.clear();
         if (devListStr.compare("")) {
@@ -146,17 +146,17 @@ QUnitMulti::QUnitMulti(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, b
     }
 #endif
 
-    const size_t devCount = devList.size() ? devList.size() : deviceContext.size();
+    const size_t devCount = devList.empty() ? deviceContext.size() : devList.size();
     for (size_t i = 0; i < devCount; ++i) {
         if (devList.size() && (devList[i] >= 0) && (devList[i] > ((int64_t)deviceContext.size()))) {
             throw std::runtime_error("QUnitMulti: Requested device doesn't exist.");
         }
         DeviceInfo deviceInfo;
         deviceInfo.id =
-            devList.size() ? ((devList[0U] < 0) ? QRACK_GPU_SINGLETON.GetDefaultDeviceID() : (size_t)devList[i]) : i;
+            devList.empty() ? i : ((devList[0U] < 0) ? QRACK_GPU_SINGLETON.GetDefaultDeviceID() : (size_t)devList[i]);
         deviceList.push_back(deviceInfo);
     }
-    if (!devList.size()) {
+    if (devList.empty()) {
         std::swap(deviceList[0U], deviceList[defaultDeviceID]);
     }
 
@@ -164,7 +164,7 @@ QUnitMulti::QUnitMulti(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, b
         deviceList[i].maxSize = deviceContext[deviceList[i].id]->GetMaxAlloc();
     }
 
-    if (!devList.size()) {
+    if (devList.empty()) {
         std::sort(deviceList.begin() + 1U, deviceList.end(), std::greater<DeviceInfo>());
     }
 }

--- a/src/wasm_api.cpp
+++ b/src/wasm_api.cpp
@@ -597,7 +597,7 @@ quid init_count_type(bitLenInt q, bool tn, bool md, bool sd, bool sh, bool bdt, 
     // (...then reverse:)
     std::reverse(simulatorType.begin(), simulatorType.end());
 
-    if (!simulatorType.size()) {
+    if (simulatorType.empty()) {
 #if ENABLE_OPENCL
         if (hy && isOcl) {
             simulatorType.push_back(QINTERFACE_HYBRID);
@@ -876,13 +876,13 @@ void PhaseParity(quid sid, real1_f lambda, std::vector<bitLenInt> q)
 real1_f _JointEnsembleProbabilityHelper(QInterfacePtr simulator, std::vector<QubitPauliBasis> q, bool doMeasure)
 {
 
-    if (!q.size()) {
+    if (q.empty()) {
         return 0.0;
     }
 
     removeIdentities(&q);
 
-    if (!q.size()) {
+    if (q.empty()) {
         return 0.0;
     }
 
@@ -1413,7 +1413,7 @@ void MCR(quid sid, real1_f phi, std::vector<bitLenInt> c, QubitPauliBasis q)
  */
 void Exp(quid sid, real1_f phi, std::vector<QubitPauliBasis> q)
 {
-    if (!q.size()) {
+    if (q.empty()) {
         return;
     }
 
@@ -1423,7 +1423,7 @@ void Exp(quid sid, real1_f phi, std::vector<QubitPauliBasis> q)
 
     removeIdentities(&q);
 
-    if (!q.size()) {
+    if (q.empty()) {
         RHelper(sid, -2 * phi, someQubit);
     } else if (q.size() == 1U) {
         RHelper(sid, -2 * phi, q.front());
@@ -1439,7 +1439,7 @@ void Exp(quid sid, real1_f phi, std::vector<QubitPauliBasis> q)
  */
 void MCExp(quid sid, real1_f phi, std::vector<bitLenInt> cs, std::vector<QubitPauliBasis> q)
 {
-    if (!q.size()) {
+    if (q.empty()) {
         return;
     }
 
@@ -1449,7 +1449,7 @@ void MCExp(quid sid, real1_f phi, std::vector<bitLenInt> cs, std::vector<QubitPa
 
     removeIdentities(&q);
 
-    if (!q.size()) {
+    if (q.empty()) {
         MCRHelper(sid, -2 * phi, cs, someQubit);
     } else if (q.size() == 1U) {
         MCRHelper(sid, -2 * phi, cs, q.front());


### PR DESCRIPTION
This PR replaces all instances of the `!size()` pattern (for a vector) with `empty()`, commonly used for conditionals all throughout Qrack. Ternary expressions on `size()` have also had their order reversed, to use `empty()`.