### PR TITLE
Pauli expectation values method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.9)
-project (Qrack VERSION 9.6.7 DESCRIPTION "High Performance Quantum Bit Simulation" LANGUAGES CXX)
+project (Qrack VERSION 9.7.0 DESCRIPTION "High Performance Quantum Bit Simulation" LANGUAGES CXX)
 
 # Installation commands
 include (GNUInstallDirs)

--- a/doxygen.config
+++ b/doxygen.config
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Qrack"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 9.6
+PROJECT_NUMBER         = 9.7
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -72,6 +72,8 @@ MICROSOFT_QUANTUM_DECL double FactorizedExpectation(
     _In_ uintq sid, _In_ uintq n, _In_reads_(n) uintq* q, _In_ uintq m, uintq* c);
 MICROSOFT_QUANTUM_DECL double FactorizedExpectationRdm(
     _In_ uintq sid, _In_ uintq n, _In_reads_(n) uintq* q, _In_ uintq m, uintq* c, _In_ bool r);
+MICROSOFT_QUANTUM_DECL double PauliExpectation(
+    _In_ uintq sid, _In_ uintq n, _In_reads_(n) uintq* q, _In_reads_(n) uintq* b);
 #if FPPOW < 6
 MICROSOFT_QUANTUM_DECL double FactorizedExpectationFp(_In_ uintq sid, _In_ uintq n, _In_reads_(n) uintq* q, float* c);
 MICROSOFT_QUANTUM_DECL double FactorizedExpectationFpRdm(

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -2479,6 +2479,7 @@ public:
      * \warning PSEUDO-QUANTUM
      */
     virtual real1_f ExpectationPauliAll(std::vector<Pauli> paulis, std::vector<bitLenInt> bits);
+
     /**
      * Get expectation value of bits, given an array of qubit weights
      *

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -2471,6 +2471,15 @@ public:
     }
 
     /**
+     * Get permutation expectation value of bits
+     *
+     * The permutation expectation value of all included bits is returned, with bits valued from low to high as the
+     * order of the "bits" array parameter argument.
+     *
+     * \warning PSEUDO-QUANTUM
+     */
+    virtual real1_f ExpectationPauliAll(std::vector<Pauli> paulis, std::vector<bitLenInt> bits);
+    /**
      * Get expectation value of bits, given an array of qubit weights
      *
      * The weighter-per-qubit expectation value of is returned, with each "bits" entry corresponding to a "perms" weight

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -2478,7 +2478,7 @@ public:
      *
      * \warning PSEUDO-QUANTUM
      */
-    virtual real1_f ExpectationPauliAll(std::vector<Pauli> paulis, std::vector<bitLenInt> bits);
+    virtual real1_f ExpectationPauliAll(std::vector<bitLenInt> bits, std::vector<Pauli> paulis);
 
     /**
      * Get expectation value of bits, given an array of qubit weights

--- a/include/wasm_api.hpp
+++ b/include/wasm_api.hpp
@@ -191,6 +191,10 @@ real1_f FactorizedExpectation(quid sid, std::vector<QubitIntegerExpectation> q);
  */
 real1_f FactorizedExpectationRdm(quid sid, std::vector<QubitIntegerExpectation> q, bool r);
 /**
+ * Pauli operator expectation value for the array of qubits and bases.
+ */
+real1_f PauliExpectation(quid sid, std::vector<bitLenInt> q, std::vector<Pauli> b);
+/**
  * Expectation value for bit-string integer from group of qubits with per-qubit real1 expectation value
  */
 real1_f FactorizedExpectationFp(quid sid, std::vector<QubitRealExpectation> q);

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -2600,11 +2600,13 @@ MICROSOFT_QUANTUM_DECL double PauliExpectation(
 {
     SIMULATOR_LOCK_GUARD_DOUBLE(sid)
 
-    std::vector<bitLenInt> _q(n);
-    std::vector<Pauli> _b(n);
+    std::vector<bitLenInt> _q;
+    std::vector<Pauli> _b;
+    _q.reserve(n);
+    _b.reserve(n);
     for (size_t i = 0U; i < n; ++i) {
-        _q[i] = (bitLenInt)q[i];
-        _b[i] = (Pauli)b[i];
+        _q.emplace_back((bitLenInt)q[i]);
+        _b.emplace_back((Pauli)b[i]);
     }
 
     return simulator->ExpectationPauliAll(_q, _b);

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -2593,6 +2593,22 @@ MICROSOFT_QUANTUM_DECL double FactorizedExpectationRdm(
 }
 
 /**
+ * (External API) Get the Pauli operator expectation value for the array of qubits and bases.
+ */
+MICROSOFT_QUANTUM_DECL double PauliExpectation(
+    _In_ uintq sid, _In_ uintq n, _In_reads_(n) uintq* q, _In_reads_(n) uintq* b)
+{
+    SIMULATOR_LOCK_GUARD_DOUBLE(sid)
+
+    std::vector<Pauli> _b(n);
+    std::transform(b, b + n, _b.begin(), [](uintq basis) { return (Pauli)basis; });
+    std::vector<bitLenInt> _q(n);
+    std::transform(q, q + n, _q.begin(), [](uintq qubit) { return (bitLenInt)qubit; });
+
+    return simulator->ExpectationPauliAll(_b, _q);
+}
+
+/**
  * (External API) Get the permutation expectation value, based upon the order of input qubits.
  */
 MICROSOFT_QUANTUM_DECL double FactorizedExpectationFp(_In_ uintq sid, _In_ uintq n, _In_reads_(n) uintq* q, real1_f* c)

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -2600,12 +2600,14 @@ MICROSOFT_QUANTUM_DECL double PauliExpectation(
 {
     SIMULATOR_LOCK_GUARD_DOUBLE(sid)
 
-    std::vector<Pauli> _b(n);
-    std::transform(b, b + n, _b.begin(), [](uintq basis) { return (Pauli)basis; });
     std::vector<bitLenInt> _q(n);
-    std::transform(q, q + n, _q.begin(), [](uintq qubit) { return (bitLenInt)qubit; });
+    std::vector<Pauli> _b(n);
+    for (size_t i = 0U; i < n; ++i) {
+        _q[i] = (bitLenInt)q[i];
+        _b[i] = (Pauli)b[i];
+    }
 
-    return simulator->ExpectationPauliAll(_b, _q);
+    return simulator->ExpectationPauliAll(_q, _b);
 }
 
 /**

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -487,6 +487,58 @@ real1_f QInterface::VarianceBitsAll(const std::vector<bitLenInt>& bits)
     return tot;
 }
 
+real1_f QInterface::ExpectationPauliAll(std::vector<Pauli> paulis, std::vector<bitLenInt> bits)
+{
+    for (size_t i = 0U; i < bits.size(); ++i) {
+        const size_t j = bits.size() - (i + 1U);
+        if (bits[j] == PauliI) {
+            bits.erase(bits.begin() + j);
+            paulis.erase(paulis.begin() + j);
+        }
+    }
+
+    std::vector<real1> eigenVals;
+    eigenVals.reserve(bits.size() << 1U);
+    for (size_t i = 0U; i < bits.size(); ++i) {
+        eigenVals.push_back(ONE_R1);
+        eigenVals.push_back(-ONE_R1);
+
+        switch (paulis[i]) {
+        case PauliX:
+            H(bits[i]);
+            break;
+        case PauliY:
+            IS(bits[i]);
+            H(bits[i]);
+            break;
+        case PauliZ:
+        case PauliI:
+        default:
+            break;
+        }
+    }
+
+    const real1_f toRet = ExpectationFloatsFactorized(bits, eigenVals);
+
+    for (size_t i = 0U; i < bits.size(); ++i) {
+        switch (paulis[i]) {
+        case PauliX:
+            H(bits[i]);
+            break;
+        case PauliY:
+            H(bits[i]);
+            S(bits[i]);
+            break;
+        case PauliZ:
+        case PauliI:
+        default:
+            break;
+        }
+    }
+
+    return toRet;
+}
+
 real1_f QInterface::ExpectationBitsFactorized(
     const std::vector<bitLenInt>& bits, const std::vector<bitCapInt>& perms, bitCapInt offset)
 {

--- a/src/qinterface/qinterface.cpp
+++ b/src/qinterface/qinterface.cpp
@@ -487,14 +487,18 @@ real1_f QInterface::VarianceBitsAll(const std::vector<bitLenInt>& bits)
     return tot;
 }
 
-real1_f QInterface::ExpectationPauliAll(std::vector<Pauli> paulis, std::vector<bitLenInt> bits)
+real1_f QInterface::ExpectationPauliAll(std::vector<bitLenInt> bits, std::vector<Pauli> paulis)
 {
     for (size_t i = 0U; i < bits.size(); ++i) {
         const size_t j = bits.size() - (i + 1U);
-        if (bits[j] == PauliI) {
+        if (paulis[j] == PauliI) {
             bits.erase(bits.begin() + j);
             paulis.erase(paulis.begin() + j);
         }
+    }
+
+    if (bits.empty()) {
+        return ONE_R1;
     }
 
     std::vector<real1> eigenVals;
@@ -551,6 +555,10 @@ real1_f QInterface::ExpectationBitsFactorized(
         "QInterface::ExpectationBitsFactorized() parameter qubits vector values must be within allocated qubit "
         "bounds!");
 
+    if (bits.empty()) {
+        return ONE_R1;
+    }
+
     if (bits.size() == 1U) {
         const real1_f prob = Prob(bits[0]);
         return (
@@ -582,6 +590,10 @@ real1_f QInterface::ExpectationFloatsFactorized(const std::vector<bitLenInt>& bi
     ThrowIfQbIdArrayIsBad(bits, qubitCount,
         "QInterface::ExpectationFloatsFactorized() parameter qubits vector values must be within allocated qubit "
         "bounds!");
+
+    if (bits.empty()) {
+        return ONE_R1;
+    }
 
     if (bits.size() == 1U) {
         const real1_f prob = Prob(bits[0]);

--- a/src/wasm_api.cpp
+++ b/src/wasm_api.cpp
@@ -1864,6 +1864,22 @@ real1_f FactorizedExpectationRdm(quid sid, std::vector<QubitIntegerExpectation> 
 }
 
 /**
+ * (External API) Get the Pauli operator expectation value for the array of qubits and bases.
+ */
+real1_f PauliExpectation(quid sid, std::vector<bitLenInt> q, std::vector<Pauli> b)
+{
+    SIMULATOR_LOCK_GUARD_REAL1_F(sid)
+
+    std::vector<bitLenInt> _q;
+    _q.reserve(q.size());
+    for (size_t i = 0U; i < q.size(); ++i) {
+        _q.push_back(shards[simulators[sid].get()][q[i]]);
+    }
+
+    return simulator->ExpectationPauliAll(b, _q);
+}
+
+/**
  * (External API) Get the permutation expectation value, based upon the order of input qubits.
  */
 real1_f FactorizedExpectationFp(quid sid, std::vector<QubitRealExpectation> q)

--- a/src/wasm_api.cpp
+++ b/src/wasm_api.cpp
@@ -1876,7 +1876,7 @@ real1_f PauliExpectation(quid sid, std::vector<bitLenInt> q, std::vector<Pauli> 
         _q.push_back(shards[simulators[sid].get()][q[i]]);
     }
 
-    return simulator->ExpectationPauliAll(b, _q);
+    return simulator->ExpectationPauliAll(_q, b);
 }
 
 /**

--- a/src/wasm_api.cpp
+++ b/src/wasm_api.cpp
@@ -1873,7 +1873,7 @@ real1_f PauliExpectation(quid sid, std::vector<bitLenInt> q, std::vector<Pauli> 
     std::vector<bitLenInt> _q;
     _q.reserve(q.size());
     for (size_t i = 0U; i < q.size(); ++i) {
-        _q.push_back(shards[simulators[sid].get()][q[i]]);
+        _q.emplace_back(shards[simulators[sid].get()][q[i]]);
     }
 
     return simulator->ExpectationPauliAll(_q, b);


### PR DESCRIPTION
This adds a method for calculating expectation values of tensor products of Pauli operator observables, and it wraps them for the shared library interfaces.