### PR TITLE
Fix build error in test case when `QBCAPPOW < 7`

### DIFF
--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1231,12 +1231,12 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_zmask")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_phaserootnmask")
 {
-    constexpr BIG_INTEGER_WORD ket = 14062;
-    constexpr BIG_INTEGER_WORD masks[6] = { 8, 3097, 22225, 16051, 62894, 49134 };
-    constexpr uint16_t n = 3;
-    const uint16_t modulus = pow2Ocl(n);
+    constexpr bitCapInt ket = 14062;
+    constexpr bitCapInt masks[6] = { 8, 3097, 22225, 16051, 62894, 49134 };
+    constexpr bitCapInt n = 3;
+    const bitCapInt modulus = pow2Ocl(n);
     // phaseCounts[ii] = popcount(ket & masks[ii])
-    constexpr uint16_t phaseCounts[6] = { 1, 2, 5, 7, 8, 10 };
+    constexpr bitCapInt phaseCounts[6] = { 1, 2, 5, 7, 8, 10 };
 
     qftReg->SetPermutation(ket);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, ket));

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1231,12 +1231,12 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_zmask")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_phaserootnmask")
 {
-    constexpr bitCapInt ket = 14062;
-    constexpr bitCapInt masks[6] = { 8, 3097, 22225, 16051, 62894, 49134 };
-    constexpr bitCapInt n = 3;
-    const bitCapInt modulus = pow2Ocl(n);
+    const bitCapInt ket = 14062;
+    const bitCapInt masks[6] = { 8, 3097, 22225, 16051, 62894, 49134 };
+    constexpr bitLenInt n = 3;
+    const bitLenInt modulus = pow2Ocl(n);
     // phaseCounts[ii] = popcount(ket & masks[ii])
-    constexpr bitCapInt phaseCounts[6] = { 1, 2, 5, 7, 8, 10 };
+    constexpr bitLenInt phaseCounts[6] = { 1, 2, 5, 7, 8, 10 };
 
     qftReg->SetPermutation(ket);
     REQUIRE_THAT(qftReg, HasProbability(0, 20, ket));


### PR DESCRIPTION
Quick fix for the build error [reported here](https://discord.com/channels/764231928676089909/934098926351573042/1254025870511706163). It looks like I assumed I could use `BIG_INTEGER_WORD` in the test, but we don't necessarily have `big_integer.hpp` included. Let me know if there is some other standard way to do this.