### PR TITLE
Fixed-point for QBDD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ endif (PACK_DEBIAN)
 add_library (qrack STATIC
     src/common/functions.cpp
     src/common/parallel_for.cpp
+    src/common/fixed.cpp
     src/qinterface/arithmetic.cpp
     src/qinterface/gates.cpp
     src/qinterface/logic.cpp
@@ -361,6 +362,7 @@ install (FILES
     include/common/dispatchqueue.hpp
     include/common/big_integer.hpp
     include/common/half.hpp
+    include/common/fixed.hpp
     include/common/qneuron_activation_function.hpp
     include/common/pauli.hpp
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/qrack/common

--- a/cmake/FpMath.cmake
+++ b/cmake/FpMath.cmake
@@ -1,5 +1,4 @@
 set(FPPOW "5" CACHE STRING "Log2 of float bits, for use in pairs as complex amplitudes (must be at least 2, equivalent to half precision)")
-option(ENABLE_FIXED_POINT "Use fixed-point math instead of floating-point" OFF)
 
 if (FPPOW LESS 4)
     message(FATAL_ERROR "FPPOW must be at least 4, equivalent to \"half\" precision!")

--- a/include/common/config.h.in
+++ b/include/common/config.h.in
@@ -4,6 +4,7 @@
 #define ENABLE_SSE3 @SSE3_MACRO@
 #cmakedefine ENABLE_DEVRAND 1
 #cmakedefine ENABLE_ENV_VARS 1
+#cmakedefine ENABLE_FIXED_POINT 1
 #cmakedefine ENABLE_INTRINSICS 1
 #cmakedefine ENABLE_OCL_MEM_GUARDS 1
 #cmakedefine ENABLE_OPENCL 1

--- a/include/common/config.h.in
+++ b/include/common/config.h.in
@@ -4,7 +4,6 @@
 #define ENABLE_SSE3 @SSE3_MACRO@
 #cmakedefine ENABLE_DEVRAND 1
 #cmakedefine ENABLE_ENV_VARS 1
-#cmakedefine ENABLE_FIXED_POINT 1
 #cmakedefine ENABLE_INTRINSICS 1
 #cmakedefine ENABLE_OCL_MEM_GUARDS 1
 #cmakedefine ENABLE_OPENCL 1

--- a/include/common/fixed.hpp
+++ b/include/common/fixed.hpp
@@ -458,231 +458,103 @@ public:
 
 // if we have the same fractional portion, but differing integer portions, we trivially upgrade the smaller type
 template <size_t I1, size_t I2, size_t F>
-CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type operator+(
-    fixed<I1, F> lhs, fixed<I2, F> rhs)
-{
-
-    using T = typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type;
-
-    const T l = T::from_base(lhs.to_raw());
-    const T r = T::from_base(rhs.to_raw());
-    return l + r;
-}
+CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type inline operator+(
+    fixed<I1, F> lhs, fixed<I2, F> rhs);
 
 template <size_t I1, size_t I2, size_t F>
-CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type operator-(
-    fixed<I1, F> lhs, fixed<I2, F> rhs)
-{
-
-    using T = typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type;
-
-    const T l = T::from_base(lhs.to_raw());
-    const T r = T::from_base(rhs.to_raw());
-    return l - r;
-}
+CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type inline operator-(
+    fixed<I1, F> lhs, fixed<I2, F> rhs);
 
 template <size_t I1, size_t I2, size_t F>
-CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type operator*(
-    fixed<I1, F> lhs, fixed<I2, F> rhs)
-{
-
-    using T = typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type;
-
-    const T l = T::from_base(lhs.to_raw());
-    const T r = T::from_base(rhs.to_raw());
-    return l * r;
-}
+CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type inline operator*(
+    fixed<I1, F> lhs, fixed<I2, F> rhs);
 
 template <size_t I1, size_t I2, size_t F>
-CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type operator/(
-    fixed<I1, F> lhs, fixed<I2, F> rhs)
-{
+CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type inline operator/(
+    fixed<I1, F> lhs, fixed<I2, F> rhs);
 
-    using T = typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type;
-
-    const T l = T::from_base(lhs.to_raw());
-    const T r = T::from_base(rhs.to_raw());
-    return l / r;
-}
-
-template <size_t I, size_t F> std::ostream& operator<<(std::ostream& os, fixed<I, F> f)
-{
-    os << f.to_double();
-    return os;
-}
+template <size_t I, size_t F> inline std::ostream& operator<<(std::ostream& os, fixed<I, F> f);
 
 // basic math operators
-template <size_t I, size_t F> CONSTEXPR14 fixed<I, F> operator+(fixed<I, F> lhs, fixed<I, F> rhs)
+template <size_t I, size_t F> CONSTEXPR14 fixed<I, F> inline operator+(fixed<I, F> lhs, fixed<I, F> rhs)
 {
     lhs += rhs;
     return lhs;
 }
 
-template <size_t I, size_t F> CONSTEXPR14 fixed<I, F> operator-(fixed<I, F> lhs, fixed<I, F> rhs)
+template <size_t I, size_t F> CONSTEXPR14 fixed<I, F> inline operator-(fixed<I, F> lhs, fixed<I, F> rhs)
 {
     lhs -= rhs;
     return lhs;
 }
 
-template <size_t I, size_t F> CONSTEXPR14 fixed<I, F> operator*(fixed<I, F> lhs, fixed<I, F> rhs)
+template <size_t I, size_t F> CONSTEXPR14 fixed<I, F> inline operator*(fixed<I, F> lhs, fixed<I, F> rhs)
 {
     lhs *= rhs;
     return lhs;
 }
 
-template <size_t I, size_t F> CONSTEXPR14 fixed<I, F> operator/(fixed<I, F> lhs, fixed<I, F> rhs)
+template <size_t I, size_t F> CONSTEXPR14 fixed<I, F> inline operator/(fixed<I, F> lhs, fixed<I, F> rhs)
 {
     lhs /= rhs;
     return lhs;
 }
 
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-CONSTEXPR14 fixed<I, F> operator+(fixed<I, F> lhs, Number rhs)
-{
-    lhs += fixed<I, F>(rhs);
-    return lhs;
-}
+template <size_t I, size_t F, class Number, class>
+CONSTEXPR14 fixed<I, F> inline operator+(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-CONSTEXPR14 fixed<I, F> operator-(fixed<I, F> lhs, Number rhs)
-{
-    lhs -= fixed<I, F>(rhs);
-    return lhs;
-}
+template <size_t I, size_t F, class Number, class>
+CONSTEXPR14 fixed<I, F> inline operator-(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-CONSTEXPR14 fixed<I, F> operator*(fixed<I, F> lhs, Number rhs)
-{
-    lhs *= fixed<I, F>(rhs);
-    return lhs;
-}
+template <size_t I, size_t F, class Number, class>
+CONSTEXPR14 fixed<I, F> inline operator*(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-CONSTEXPR14 fixed<I, F> operator/(fixed<I, F> lhs, Number rhs)
-{
-    lhs /= fixed<I, F>(rhs);
-    return lhs;
-}
+template <size_t I, size_t F, class Number, class>
+CONSTEXPR14 fixed<I, F> inline operator/(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-CONSTEXPR14 fixed<I, F> operator+(Number lhs, fixed<I, F> rhs)
-{
-    fixed<I, F> tmp(lhs);
-    tmp += rhs;
-    return tmp;
-}
+template <size_t I, size_t F, class Number, class>
+CONSTEXPR14 fixed<I, F> inline operator+(Number lhs, fixed<I, F> rhs);
 
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-CONSTEXPR14 fixed<I, F> operator-(Number lhs, fixed<I, F> rhs)
-{
-    fixed<I, F> tmp(lhs);
-    tmp -= rhs;
-    return tmp;
-}
+template <size_t I, size_t F, class Number, class>
+CONSTEXPR14 fixed<I, F> inline operator-(Number lhs, fixed<I, F> rhs);
 
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-CONSTEXPR14 fixed<I, F> operator*(Number lhs, fixed<I, F> rhs)
-{
-    fixed<I, F> tmp(lhs);
-    tmp *= rhs;
-    return tmp;
-}
+template <size_t I, size_t F, class Number, class>
+CONSTEXPR14 fixed<I, F> inline operator*(Number lhs, fixed<I, F> rhs);
 
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-CONSTEXPR14 fixed<I, F> operator/(Number lhs, fixed<I, F> rhs)
-{
-    fixed<I, F> tmp(lhs);
-    tmp /= rhs;
-    return tmp;
-}
+template <size_t I, size_t F, class Number, class>
+CONSTEXPR14 fixed<I, F> inline operator/(Number lhs, fixed<I, F> rhs);
 
 // shift operators
-template <size_t I, size_t F, class Integer, class = typename std::enable_if<std::is_integral<Integer>::value>::type>
-CONSTEXPR14 fixed<I, F> operator<<(fixed<I, F> lhs, Integer rhs)
-{
-    lhs <<= rhs;
-    return lhs;
-}
+template <size_t I, size_t F, class Integer, class>
+CONSTEXPR14 fixed<I, F> inline operator<<(fixed<I, F> lhs, Integer rhs);
 
-template <size_t I, size_t F, class Integer, class = typename std::enable_if<std::is_integral<Integer>::value>::type>
-CONSTEXPR14 fixed<I, F> operator>>(fixed<I, F> lhs, Integer rhs)
-{
-    lhs >>= rhs;
-    return lhs;
-}
+template <size_t I, size_t F, class Integer, class>
+CONSTEXPR14 fixed<I, F> inline operator>>(fixed<I, F> lhs, Integer rhs);
 
 // comparison operators
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-constexpr bool operator>(fixed<I, F> lhs, Number rhs)
-{
-    return lhs > fixed<I, F>(rhs);
-}
+template <size_t I, size_t F, class Number, class> constexpr bool inline operator>(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-constexpr bool operator<(fixed<I, F> lhs, Number rhs)
-{
-    return lhs < fixed<I, F>(rhs);
-}
+template <size_t I, size_t F, class Number, class> constexpr bool inline operator<(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-constexpr bool operator>=(fixed<I, F> lhs, Number rhs)
-{
-    return lhs >= fixed<I, F>(rhs);
-}
+template <size_t I, size_t F, class Number, class> constexpr bool inline operator>=(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-constexpr bool operator<=(fixed<I, F> lhs, Number rhs)
-{
-    return lhs <= fixed<I, F>(rhs);
-}
+template <size_t I, size_t F, class Number, class> constexpr bool inline operator<=(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-constexpr bool operator==(fixed<I, F> lhs, Number rhs)
-{
-    return lhs == fixed<I, F>(rhs);
-}
+template <size_t I, size_t F, class Number, class> constexpr bool inline operator==(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-constexpr bool operator!=(fixed<I, F> lhs, Number rhs)
-{
-    return lhs != fixed<I, F>(rhs);
-}
+template <size_t I, size_t F, class Number, class> constexpr bool inline operator!=(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-constexpr bool operator>(Number lhs, fixed<I, F> rhs)
-{
-    return fixed<I, F>(lhs) > rhs;
-}
+template <size_t I, size_t F, class Number, class> constexpr bool inline operator>(Number lhs, fixed<I, F> rhs);
 
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-constexpr bool operator<(Number lhs, fixed<I, F> rhs)
-{
-    return fixed<I, F>(lhs) < rhs;
-}
+template <size_t I, size_t F, class Number, class> constexpr bool inline operator<(Number lhs, fixed<I, F> rhs);
 
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-constexpr bool operator>=(Number lhs, fixed<I, F> rhs)
-{
-    return fixed<I, F>(lhs) >= rhs;
-}
+template <size_t I, size_t F, class Number, class> constexpr bool inline operator>=(Number lhs, fixed<I, F> rhs);
 
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-constexpr bool operator<=(Number lhs, fixed<I, F> rhs)
-{
-    return fixed<I, F>(lhs) <= rhs;
-}
+template <size_t I, size_t F, class Number, class> constexpr bool inline operator<=(Number lhs, fixed<I, F> rhs);
 
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-constexpr bool operator==(Number lhs, fixed<I, F> rhs)
-{
-    return fixed<I, F>(lhs) == rhs;
-}
+template <size_t I, size_t F, class Number, class> constexpr bool inline operator==(Number lhs, fixed<I, F> rhs);
 
-template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
-constexpr bool operator!=(Number lhs, fixed<I, F> rhs)
-{
-    return fixed<I, F>(lhs) != rhs;
-}
+template <size_t I, size_t F, class Number, class> constexpr bool inline operator!=(Number lhs, fixed<I, F> rhs);
 
 } // namespace numeric
 

--- a/include/common/fixed.hpp
+++ b/include/common/fixed.hpp
@@ -458,22 +458,22 @@ public:
 
 // if we have the same fractional portion, but differing integer portions, we trivially upgrade the smaller type
 template <size_t I1, size_t I2, size_t F>
-CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type inline operator+(
+CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type operator+(
     fixed<I1, F> lhs, fixed<I2, F> rhs);
 
 template <size_t I1, size_t I2, size_t F>
-CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type inline operator-(
+CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type operator-(
     fixed<I1, F> lhs, fixed<I2, F> rhs);
 
 template <size_t I1, size_t I2, size_t F>
-CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type inline operator*(
+CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type operator*(
     fixed<I1, F> lhs, fixed<I2, F> rhs);
 
 template <size_t I1, size_t I2, size_t F>
-CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type inline operator/(
+CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type operator/(
     fixed<I1, F> lhs, fixed<I2, F> rhs);
 
-template <size_t I, size_t F> inline std::ostream& operator<<(std::ostream& os, fixed<I, F> f);
+template <size_t I, size_t F> std::ostream& operator<<(std::ostream& os, fixed<I, F> f);
 
 // basic math operators
 template <size_t I, size_t F> CONSTEXPR14 fixed<I, F> inline operator+(fixed<I, F> lhs, fixed<I, F> rhs)
@@ -500,61 +500,51 @@ template <size_t I, size_t F> CONSTEXPR14 fixed<I, F> inline operator/(fixed<I, 
     return lhs;
 }
 
-template <size_t I, size_t F, class Number, class>
-CONSTEXPR14 fixed<I, F> inline operator+(fixed<I, F> lhs, Number rhs);
+template <size_t I, size_t F, class Number, class> CONSTEXPR14 fixed<I, F> operator+(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class>
-CONSTEXPR14 fixed<I, F> inline operator-(fixed<I, F> lhs, Number rhs);
+template <size_t I, size_t F, class Number, class> CONSTEXPR14 fixed<I, F> operator-(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class>
-CONSTEXPR14 fixed<I, F> inline operator*(fixed<I, F> lhs, Number rhs);
+template <size_t I, size_t F, class Number, class> CONSTEXPR14 fixed<I, F> operator*(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class>
-CONSTEXPR14 fixed<I, F> inline operator/(fixed<I, F> lhs, Number rhs);
+template <size_t I, size_t F, class Number, class> CONSTEXPR14 fixed<I, F> operator/(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class>
-CONSTEXPR14 fixed<I, F> inline operator+(Number lhs, fixed<I, F> rhs);
+template <size_t I, size_t F, class Number, class> CONSTEXPR14 fixed<I, F> operator+(Number lhs, fixed<I, F> rhs);
 
-template <size_t I, size_t F, class Number, class>
-CONSTEXPR14 fixed<I, F> inline operator-(Number lhs, fixed<I, F> rhs);
+template <size_t I, size_t F, class Number, class> CONSTEXPR14 fixed<I, F> operator-(Number lhs, fixed<I, F> rhs);
 
-template <size_t I, size_t F, class Number, class>
-CONSTEXPR14 fixed<I, F> inline operator*(Number lhs, fixed<I, F> rhs);
+template <size_t I, size_t F, class Number, class> CONSTEXPR14 fixed<I, F> operator*(Number lhs, fixed<I, F> rhs);
 
-template <size_t I, size_t F, class Number, class>
-CONSTEXPR14 fixed<I, F> inline operator/(Number lhs, fixed<I, F> rhs);
+template <size_t I, size_t F, class Number, class> CONSTEXPR14 fixed<I, F> operator/(Number lhs, fixed<I, F> rhs);
 
 // shift operators
-template <size_t I, size_t F, class Integer, class>
-CONSTEXPR14 fixed<I, F> inline operator<<(fixed<I, F> lhs, Integer rhs);
+template <size_t I, size_t F, class Integer, class> CONSTEXPR14 fixed<I, F> operator<<(fixed<I, F> lhs, Integer rhs);
 
-template <size_t I, size_t F, class Integer, class>
-CONSTEXPR14 fixed<I, F> inline operator>>(fixed<I, F> lhs, Integer rhs);
+template <size_t I, size_t F, class Integer, class> CONSTEXPR14 fixed<I, F> operator>>(fixed<I, F> lhs, Integer rhs);
 
 // comparison operators
-template <size_t I, size_t F, class Number, class> constexpr bool inline operator>(fixed<I, F> lhs, Number rhs);
+template <size_t I, size_t F, class Number, class> constexpr bool operator>(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class> constexpr bool inline operator<(fixed<I, F> lhs, Number rhs);
+template <size_t I, size_t F, class Number, class> constexpr bool operator<(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class> constexpr bool inline operator>=(fixed<I, F> lhs, Number rhs);
+template <size_t I, size_t F, class Number, class> constexpr bool operator>=(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class> constexpr bool inline operator<=(fixed<I, F> lhs, Number rhs);
+template <size_t I, size_t F, class Number, class> constexpr bool operator<=(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class> constexpr bool inline operator==(fixed<I, F> lhs, Number rhs);
+template <size_t I, size_t F, class Number, class> constexpr bool operator==(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class> constexpr bool inline operator!=(fixed<I, F> lhs, Number rhs);
+template <size_t I, size_t F, class Number, class> constexpr bool operator!=(fixed<I, F> lhs, Number rhs);
 
-template <size_t I, size_t F, class Number, class> constexpr bool inline operator>(Number lhs, fixed<I, F> rhs);
+template <size_t I, size_t F, class Number, class> constexpr bool operator>(Number lhs, fixed<I, F> rhs);
 
-template <size_t I, size_t F, class Number, class> constexpr bool inline operator<(Number lhs, fixed<I, F> rhs);
+template <size_t I, size_t F, class Number, class> constexpr bool operator<(Number lhs, fixed<I, F> rhs);
 
-template <size_t I, size_t F, class Number, class> constexpr bool inline operator>=(Number lhs, fixed<I, F> rhs);
+template <size_t I, size_t F, class Number, class> constexpr bool operator>=(Number lhs, fixed<I, F> rhs);
 
-template <size_t I, size_t F, class Number, class> constexpr bool inline operator<=(Number lhs, fixed<I, F> rhs);
+template <size_t I, size_t F, class Number, class> constexpr bool operator<=(Number lhs, fixed<I, F> rhs);
 
-template <size_t I, size_t F, class Number, class> constexpr bool inline operator==(Number lhs, fixed<I, F> rhs);
+template <size_t I, size_t F, class Number, class> constexpr bool operator==(Number lhs, fixed<I, F> rhs);
 
-template <size_t I, size_t F, class Number, class> constexpr bool inline operator!=(Number lhs, fixed<I, F> rhs);
+template <size_t I, size_t F, class Number, class> constexpr bool operator!=(Number lhs, fixed<I, F> rhs);
 
 } // namespace numeric
 

--- a/include/common/qrack_functions.hpp
+++ b/include/common/qrack_functions.hpp
@@ -208,11 +208,7 @@ bool isOverflowSub(
 bitCapInt pushApartBits(const bitCapInt& perm, const std::vector<bitCapInt>& skipPowers);
 bitCapInt intPow(bitCapInt base, bitCapInt power);
 bitCapIntOcl intPowOcl(bitCapIntOcl base, bitCapIntOcl power);
-
-complex complexFixedToFloating(complex_x f)
-{
-    return complex((real1)(real(f).to_double()), (real1)(imag(f).to_double()));
-}
+complex complexFixedToFloating(complex_x f);
 
 #if QBCAPPOW > 6
 std::ostream& operator<<(std::ostream& os, bitCapInt b);

--- a/include/common/qrack_functions.hpp
+++ b/include/common/qrack_functions.hpp
@@ -209,6 +209,11 @@ bitCapInt pushApartBits(const bitCapInt& perm, const std::vector<bitCapInt>& ski
 bitCapInt intPow(bitCapInt base, bitCapInt power);
 bitCapIntOcl intPowOcl(bitCapIntOcl base, bitCapIntOcl power);
 
+complex complexFixedToFloating(complex_x f)
+{
+    return complex((real1)(real(f).to_double()), (real1)(imag(f).to_double()));
+}
+
 #if QBCAPPOW > 6
 std::ostream& operator<<(std::ostream& os, bitCapInt b);
 std::istream& operator>>(std::istream& is, bitCapInt& b);

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -255,19 +255,7 @@ QRACK_CONST complex ONE_CMPLX = complex(ONE_R1, ZERO_R1);
 QRACK_CONST complex ZERO_CMPLX = complex(ZERO_R1, ZERO_R1);
 QRACK_CONST complex I_CMPLX = complex(ZERO_R1, ONE_R1);
 QRACK_CONST complex CMPLX_DEFAULT_ARG = complex(REAL1_DEFAULT_ARG, REAL1_DEFAULT_ARG);
-#if ENABLE_FIXED_POINT
-#if FPPOW < 5
-QRACK_CONST real1 FP_NORM_EPSILON = (real1)(std::numeric_limits<float16_t>::epsilon() / 2);
-#elif FPPOW < 6
-QRACK_CONST real1 FP_NORM_EPSILON = (real1)(std::numeric_limits<float>::epsilon() / 2);
-#elif FPPOW < 7
-QRACK_CONST real1 FP_NORM_EPSILON = (real1)(std::numeric_limits<double>::epsilon() / 2);
-#else
-QRACK_CONST real1 FP_NORM_EPSILON = (real1)(std::numeric_limits<boost::multiprecision::float128>::epsilon() / 2);
-#endif
-#else
 QRACK_CONST real1 FP_NORM_EPSILON = (real1)(std::numeric_limits<real1>::epsilon() / 2);
-#endif
 QRACK_CONST real1_f TRYDECOMPOSE_EPSILON = (real1_f)(16 * FP_NORM_EPSILON);
 constexpr real1_f FP_NORM_EPSILON_F = std::numeric_limits<real1_f>::epsilon() / 2;
 } // namespace Qrack

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -126,7 +126,7 @@ constexpr bitLenInt bitsInCap = ((bitLenInt)1U) << ((bitLenInt)QBCAPPOW);
 // (and no less, for maximum capacity).
 // 1 bit is +/- sign.
 // 1 bit is 0/1 on the left side of the decimal point.
-typedef numeric::fixed<2U, (1U << FPPOW) - 2U> real1_x;
+typedef numeric::fixed<3U, (1U << FPPOW) - 3U> real1_x;
 typedef std::complex<real1_x> complex_x;
 constexpr real1_x ONE_R1_X = 1.0f;
 constexpr real1_x ZERO_R1_X = 0.0f;

--- a/include/common/qrack_types.hpp
+++ b/include/common/qrack_types.hpp
@@ -63,25 +63,8 @@
 #define bitCapInt BigInteger
 #endif
 
-#if ENABLE_FIXED_POINT
 #include "fixed.hpp"
-namespace Qrack {
-// We want to be able to represent at least 2 * PI_R1.
-// (This is <7.) 1 bit is sign.
-// 3 bits represent 1, 2, and 4, for a maximum value of 7
-// on the left side of the decimal point.
-typedef numeric::Fixed<4U, (1U << FPPOW) - 4U> real1;
-#if FPPOW < 6
-typedef float real1_f;
-typedef float real1_s;
-#elif FPPOW < 7
-typedef double real1_f;
-typedef double real1_s;
-#else
-typedef boost::multiprecision::float128 real1_f;
-typedef double real1_s;
-#endif
-#else
+
 #if FPPOW < 5
 #ifdef __arm__
 namespace Qrack {
@@ -133,12 +116,24 @@ typedef boost::multiprecision::float128 real1_f;
 typedef double real1_s;
 #endif
 #endif
-#endif
 
 typedef std::complex<real1> complex;
 const bitCapInt ONE_BCI = 1U;
 const bitCapInt ZERO_BCI = 0U;
 constexpr bitLenInt bitsInCap = ((bitLenInt)1U) << ((bitLenInt)QBCAPPOW);
+
+// We want to be able to represent at least 1
+// (and no less, for maximum capacity).
+// 1 bit is +/- sign.
+// 1 bit is 0/1 on the left side of the decimal point.
+typedef numeric::fixed<2U, (1U << FPPOW) - 2U> real1_x;
+typedef std::complex<real1_x> complex_x;
+constexpr real1_x ONE_R1_X = 1.0f;
+constexpr real1_x ZERO_R1_X = 0.0f;
+constexpr complex_x ONE_CMPLX_X = complex_x(ONE_R1_X, ZERO_R1_X);
+constexpr complex_x ZERO_CMPLX_X = complex_x(ZERO_R1_X, ZERO_R1_X);
+constexpr complex_x I_CMPLX_X = complex_x(ZERO_R1_X, ONE_R1_X);
+const real1_x SQRT1_2_R1_X = (real1_x)M_SQRT1_2;
 
 typedef std::shared_ptr<complex> BitOp;
 
@@ -172,7 +167,7 @@ const real1 ZERO_R1 = (real1)0.0f;
 constexpr real1_f ZERO_R1_F = 0.0f;
 const real1 ONE_R1 = (real1)1.0f;
 constexpr real1_f ONE_R1_F = 1.0f;
-const real1 REAL1_DEFAULT_ARG = (real1)-999.0f;
+const real1 REAL1_DEFAULT_ARG = (real1)-7.77f;
 // Half the probability in any single permutation of 20 maximally superposed qubits
 const real1 REAL1_EPSILON = (real1)0.000000477f;
 const real1 PI_R1 = (real1)M_PI;
@@ -187,7 +182,7 @@ const real1 SQRT1_2_R1 = (real1)M_SQRT1_2;
 constexpr real1 PI_R1 = (real1)M_PI;
 constexpr real1 SQRT2_R1 = (real1)M_SQRT2;
 constexpr real1 SQRT1_2_R1 = (real1)M_SQRT1_2;
-#define REAL1_DEFAULT_ARG -999.0f
+#define REAL1_DEFAULT_ARG -7.77f
 // Half the probability in any single permutation of 48 maximally superposed qubits
 #define REAL1_EPSILON 1.7763568394002505e-15f
 #elif FPPOW < 7
@@ -199,7 +194,7 @@ constexpr real1 SQRT1_2_R1 = (real1)M_SQRT1_2;
 #define PI_R1 M_PI
 #define SQRT2_R1 M_SQRT2
 #define SQRT1_2_R1 M_SQRT1_2
-#define REAL1_DEFAULT_ARG -999.0
+#define REAL1_DEFAULT_ARG -7.77
 // Half the probability in any single permutation of 96 maximally superposed qubits
 #define REAL1_EPSILON 6.310887241768095e-30
 #else
@@ -211,7 +206,7 @@ constexpr real1 ONE_R1 = (real1)1.0;
 constexpr real1_f PI_R1 = (real1_f)M_PI;
 constexpr real1_f SQRT2_R1 = (real1_f)M_SQRT2;
 constexpr real1_f SQRT1_2_R1 = (real1_f)M_SQRT1_2;
-#define REAL1_DEFAULT_ARG -999.0
+#define REAL1_DEFAULT_ARG -7.77
 // Half the probability in any single permutation of 192 maximally superposed qubits
 #define REAL1_EPSILON 7.965459555662261e-59
 #endif
@@ -260,7 +255,19 @@ QRACK_CONST complex ONE_CMPLX = complex(ONE_R1, ZERO_R1);
 QRACK_CONST complex ZERO_CMPLX = complex(ZERO_R1, ZERO_R1);
 QRACK_CONST complex I_CMPLX = complex(ZERO_R1, ONE_R1);
 QRACK_CONST complex CMPLX_DEFAULT_ARG = complex(REAL1_DEFAULT_ARG, REAL1_DEFAULT_ARG);
+#if ENABLE_FIXED_POINT
+#if FPPOW < 5
+QRACK_CONST real1 FP_NORM_EPSILON = (real1)(std::numeric_limits<float16_t>::epsilon() / 2);
+#elif FPPOW < 6
+QRACK_CONST real1 FP_NORM_EPSILON = (real1)(std::numeric_limits<float>::epsilon() / 2);
+#elif FPPOW < 7
+QRACK_CONST real1 FP_NORM_EPSILON = (real1)(std::numeric_limits<double>::epsilon() / 2);
+#else
+QRACK_CONST real1 FP_NORM_EPSILON = (real1)(std::numeric_limits<boost::multiprecision::float128>::epsilon() / 2);
+#endif
+#else
 QRACK_CONST real1 FP_NORM_EPSILON = (real1)(std::numeric_limits<real1>::epsilon() / 2);
+#endif
 QRACK_CONST real1_f TRYDECOMPOSE_EPSILON = (real1_f)(16 * FP_NORM_EPSILON);
 constexpr real1_f FP_NORM_EPSILON_F = std::numeric_limits<real1_f>::epsilon() / 2;
 } // namespace Qrack

--- a/include/qbdt.hpp
+++ b/include/qbdt.hpp
@@ -96,7 +96,7 @@ protected:
 
         _par_for(maxQPower, [&](const bitCapInt& i, const unsigned& cpu) {
             QBdtNodeInterfacePtr leaf = root;
-            complex scale = leaf->scale;
+            complex_x scale = leaf->scale;
             for (bitLenInt j = 0U; j < qubitCount; ++j) {
                 leaf = leaf->branches[SelectBit(i, j)];
                 if (!leaf) {
@@ -105,7 +105,7 @@ protected:
                 scale *= leaf->scale;
             }
 
-            getLambda((bitCapIntOcl)i, scale);
+            getLambda((bitCapIntOcl)i, complex((real1)(real(scale).to_double()), (real1)(imag(scale).to_double())));
         });
     }
     template <typename Fn> void SetTraversal(Fn setLambda)

--- a/include/qbdt_node.hpp
+++ b/include/qbdt_node.hpp
@@ -25,14 +25,8 @@ typedef std::shared_ptr<QBdtNode> QBdtNodePtr;
 
 class QBdtNode : public QBdtNodeInterface {
 protected:
-#if ENABLE_COMPLEX_X2
-    virtual void PushStateVector(const complex2& mtrxCol1, const complex2& mtrxCol2, const complex2& mtrxColShuff1,
-        const complex2& mtrxColShuff2, QBdtNodeInterfacePtr& b0, QBdtNodeInterfacePtr& b1, bitLenInt depth,
-        bitLenInt parDepth = 1U);
-#else
-    virtual void PushStateVector(complex const* mtrx, QBdtNodeInterfacePtr& b0, QBdtNodeInterfacePtr& b1,
+    virtual void PushStateVector(complex_x const* mtrx, QBdtNodeInterfacePtr& b0, QBdtNodeInterfacePtr& b1,
         bitLenInt depth, bitLenInt parDepth = 1U);
-#endif
 
 public:
     QBdtNode()
@@ -41,13 +35,13 @@ public:
         // Intentionally left blank
     }
 
-    QBdtNode(complex scl)
+    QBdtNode(complex_x scl)
         : QBdtNodeInterface(scl)
     {
         // Intentionally left blank
     }
 
-    QBdtNode(complex scl, QBdtNodeInterfacePtr* b)
+    QBdtNode(complex_x scl, QBdtNodeInterfacePtr* b)
         : QBdtNodeInterface(scl, b)
     {
         // Intentionally left blank
@@ -70,12 +64,7 @@ public:
 
     virtual void Normalize(bitLenInt depth = 1U);
 
-#if ENABLE_COMPLEX_X2
-    virtual void Apply2x2(const complex2& mtrxCol1, const complex2& mtrxCol2, const complex2& mtrxColShuff1,
-        const complex2& mtrxColShuff2, bitLenInt depth);
-#else
-    virtual void Apply2x2(complex const* mtrx, bitLenInt depth);
-#endif
+    virtual void Apply2x2(complex_x const* mtrx, bitLenInt depth);
 };
 
 } // namespace Qrack

--- a/include/qbdt_node_interface.hpp
+++ b/include/qbdt_node_interface.hpp
@@ -20,14 +20,6 @@
 
 #include <mutex>
 
-#if ENABLE_COMPLEX_X2
-#if FPPOW == 5
-#include "common/complex8x2simd.hpp"
-#elif FPPOW == 6
-#include "common/complex16x2simd.hpp"
-#endif
-#endif
-
 namespace Qrack {
 
 class QBdtNodeInterface;
@@ -39,40 +31,34 @@ protected:
     static void _par_for_qbdt(const bitCapInt end, BdtFunc fn);
 
 public:
-#if ENABLE_COMPLEX_X2
-    virtual void PushStateVector(const complex2& mtrxCol1, const complex2& mtrxCol2, const complex2& mtrxColShuff1,
-        const complex2& mtrxColShuff2, QBdtNodeInterfacePtr& b0, QBdtNodeInterfacePtr& b1, bitLenInt depth,
-        bitLenInt parDepth = 1U)
-#else
-    virtual void PushStateVector(complex const* mtrx, QBdtNodeInterfacePtr& b0, QBdtNodeInterfacePtr& b1,
+    virtual void PushStateVector(complex_x const* mtrx, QBdtNodeInterfacePtr& b0, QBdtNodeInterfacePtr& b1,
         bitLenInt depth, bitLenInt parDepth = 1U)
-#endif
     {
         throw std::out_of_range("QBdtNodeInterface::PushStateVector() not implemented! (You probably set "
                                 "QRACK_QBDT_SEPARABILITY_THRESHOLD too high.)");
     }
 
-    complex scale;
+    complex_x scale;
     QBdtNodeInterfacePtr branches[2U];
 #if ENABLE_QBDT_CPU_PARALLEL && ENABLE_PTHREAD
     std::mutex mtx;
 #endif
 
     QBdtNodeInterface()
-        : scale(ONE_CMPLX)
+        : scale(ONE_CMPLX_X)
     {
         branches[0U] = NULL;
         branches[1U] = NULL;
     }
 
-    QBdtNodeInterface(complex scl)
+    QBdtNodeInterface(complex_x scl)
         : scale(scl)
     {
         branches[0U] = NULL;
         branches[1U] = NULL;
     }
 
-    QBdtNodeInterface(complex scl, QBdtNodeInterfacePtr* b)
+    QBdtNodeInterface(complex_x scl, QBdtNodeInterfacePtr* b)
         : scale(scl)
     {
         branches[0U] = b[0U];
@@ -167,12 +153,7 @@ public:
                                 "QRACK_QBDT_SEPARABILITY_THRESHOLD too high.)");
     }
 
-#if ENABLE_COMPLEX_X2
-    virtual void Apply2x2(const complex2& mtrxCol1, const complex2& mtrxCol2, const complex2& mtrxColShuff1,
-        const complex2& mtrxColShuff2, bitLenInt depth)
-#else
-    virtual void Apply2x2(complex const* mtrx, bitLenInt depth)
-#endif
+    virtual void Apply2x2(complex_x const* mtrx, bitLenInt depth)
     {
         if (!depth) {
             return;
@@ -182,12 +163,7 @@ public:
                                 "QRACK_QBDT_SEPARABILITY_THRESHOLD too high.)");
     }
 
-#if ENABLE_COMPLEX_X2
-    virtual void PushSpecial(const complex2& mtrxCol1, const complex2& mtrxCol2, const complex2& mtrxColShuff1,
-        const complex2& mtrxColShuff2, QBdtNodeInterfacePtr& b1)
-#else
-    virtual void PushSpecial(complex const* mtrx, QBdtNodeInterfacePtr& b1)
-#endif
+    virtual void PushSpecial(complex_x const* mtrx, QBdtNodeInterfacePtr& b1)
     {
         throw std::out_of_range("QBdtNodeInterface::PushSpecial() not implemented! (You probably called "
                                 "PushStateVector() past terminal depth.)");

--- a/src/common/fixed.cpp
+++ b/src/common/fixed.cpp
@@ -32,12 +32,6 @@
 #define CONSTEXPR14
 #endif
 
-#include <cstddef> // for size_t
-#include <cstdint>
-#include <exception>
-#include <ostream>
-#include <type_traits>
-
 namespace numeric {
 
 // if we have the same fractional portion, but differing integer portions, we trivially upgrade the smaller type

--- a/src/common/fixed.cpp
+++ b/src/common/fixed.cpp
@@ -1,0 +1,247 @@
+// From: https://github.com/eteran/cpp-utilities/blob/master/fixed/include/cpp-utilities/fixed.h
+// See also: http://stackoverflow.com/questions/79677/whats-the-best-way-to-do-fixed-point-math
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Evan Teran
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "common/fixed.hpp"
+
+#if __cplusplus >= 201402L
+#define CONSTEXPR14 constexpr
+#else
+#define CONSTEXPR14
+#endif
+
+#include <cstddef> // for size_t
+#include <cstdint>
+#include <exception>
+#include <ostream>
+#include <type_traits>
+
+namespace numeric {
+
+// if we have the same fractional portion, but differing integer portions, we trivially upgrade the smaller type
+template <size_t I1, size_t I2, size_t F>
+CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type operator+(
+    fixed<I1, F> lhs, fixed<I2, F> rhs)
+{
+
+    using T = typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type;
+
+    const T l = T::from_base(lhs.to_raw());
+    const T r = T::from_base(rhs.to_raw());
+    return l + r;
+}
+
+template <size_t I1, size_t I2, size_t F>
+CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type operator-(
+    fixed<I1, F> lhs, fixed<I2, F> rhs)
+{
+
+    using T = typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type;
+
+    const T l = T::from_base(lhs.to_raw());
+    const T r = T::from_base(rhs.to_raw());
+    return l - r;
+}
+
+template <size_t I1, size_t I2, size_t F>
+CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type operator*(
+    fixed<I1, F> lhs, fixed<I2, F> rhs)
+{
+
+    using T = typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type;
+
+    const T l = T::from_base(lhs.to_raw());
+    const T r = T::from_base(rhs.to_raw());
+    return l * r;
+}
+
+template <size_t I1, size_t I2, size_t F>
+CONSTEXPR14 typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type operator/(
+    fixed<I1, F> lhs, fixed<I2, F> rhs)
+{
+
+    using T = typename std::conditional<I1 >= I2, fixed<I1, F>, fixed<I2, F>>::type;
+
+    const T l = T::from_base(lhs.to_raw());
+    const T r = T::from_base(rhs.to_raw());
+    return l / r;
+}
+
+template <size_t I, size_t F> std::ostream& operator<<(std::ostream& os, fixed<I, F> f)
+{
+    os << f.to_double();
+    return os;
+}
+
+// basic math operators
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+CONSTEXPR14 fixed<I, F> operator+(fixed<I, F> lhs, Number rhs)
+{
+    lhs += fixed<I, F>(rhs);
+    return lhs;
+}
+
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+CONSTEXPR14 fixed<I, F> operator-(fixed<I, F> lhs, Number rhs)
+{
+    lhs -= fixed<I, F>(rhs);
+    return lhs;
+}
+
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+CONSTEXPR14 fixed<I, F> operator*(fixed<I, F> lhs, Number rhs)
+{
+    lhs *= fixed<I, F>(rhs);
+    return lhs;
+}
+
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+CONSTEXPR14 fixed<I, F> operator/(fixed<I, F> lhs, Number rhs)
+{
+    lhs /= fixed<I, F>(rhs);
+    return lhs;
+}
+
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+CONSTEXPR14 fixed<I, F> operator+(Number lhs, fixed<I, F> rhs)
+{
+    fixed<I, F> tmp(lhs);
+    tmp += rhs;
+    return tmp;
+}
+
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+CONSTEXPR14 fixed<I, F> operator-(Number lhs, fixed<I, F> rhs)
+{
+    fixed<I, F> tmp(lhs);
+    tmp -= rhs;
+    return tmp;
+}
+
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+CONSTEXPR14 fixed<I, F> operator*(Number lhs, fixed<I, F> rhs)
+{
+    fixed<I, F> tmp(lhs);
+    tmp *= rhs;
+    return tmp;
+}
+
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+CONSTEXPR14 fixed<I, F> operator/(Number lhs, fixed<I, F> rhs)
+{
+    fixed<I, F> tmp(lhs);
+    tmp /= rhs;
+    return tmp;
+}
+
+// shift operators
+template <size_t I, size_t F, class Integer, class = typename std::enable_if<std::is_integral<Integer>::value>::type>
+CONSTEXPR14 fixed<I, F> operator<<(fixed<I, F> lhs, Integer rhs)
+{
+    lhs <<= rhs;
+    return lhs;
+}
+
+template <size_t I, size_t F, class Integer, class = typename std::enable_if<std::is_integral<Integer>::value>::type>
+CONSTEXPR14 fixed<I, F> operator>>(fixed<I, F> lhs, Integer rhs)
+{
+    lhs >>= rhs;
+    return lhs;
+}
+
+// comparison operators
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+constexpr bool operator>(fixed<I, F> lhs, Number rhs)
+{
+    return lhs > fixed<I, F>(rhs);
+}
+
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+constexpr bool operator<(fixed<I, F> lhs, Number rhs)
+{
+    return lhs < fixed<I, F>(rhs);
+}
+
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+constexpr bool operator>=(fixed<I, F> lhs, Number rhs)
+{
+    return lhs >= fixed<I, F>(rhs);
+}
+
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+constexpr bool operator<=(fixed<I, F> lhs, Number rhs)
+{
+    return lhs <= fixed<I, F>(rhs);
+}
+
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+constexpr bool operator==(fixed<I, F> lhs, Number rhs)
+{
+    return lhs == fixed<I, F>(rhs);
+}
+
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+constexpr bool operator!=(fixed<I, F> lhs, Number rhs)
+{
+    return lhs != fixed<I, F>(rhs);
+}
+
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+constexpr bool operator>(Number lhs, fixed<I, F> rhs)
+{
+    return fixed<I, F>(lhs) > rhs;
+}
+
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+constexpr bool operator<(Number lhs, fixed<I, F> rhs)
+{
+    return fixed<I, F>(lhs) < rhs;
+}
+
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+constexpr bool operator>=(Number lhs, fixed<I, F> rhs)
+{
+    return fixed<I, F>(lhs) >= rhs;
+}
+
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+constexpr bool operator<=(Number lhs, fixed<I, F> rhs)
+{
+    return fixed<I, F>(lhs) <= rhs;
+}
+
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+constexpr bool operator==(Number lhs, fixed<I, F> rhs)
+{
+    return fixed<I, F>(lhs) == rhs;
+}
+
+template <size_t I, size_t F, class Number, class = typename std::enable_if<std::is_arithmetic<Number>::value>::type>
+constexpr bool operator!=(Number lhs, fixed<I, F> rhs)
+{
+    return fixed<I, F>(lhs) != rhs;
+}
+
+} // namespace numeric

--- a/src/common/functions.cpp
+++ b/src/common/functions.cpp
@@ -90,6 +90,10 @@ bitCapIntOcl intPowOcl(bitCapIntOcl base, bitCapIntOcl power)
 
     return tmp;
 }
+complex complexFixedToFloating(complex_x f)
+{
+    return complex((real1)(real(f).to_double()), (real1)(imag(f).to_double()));
+}
 
 #if ENABLE_COMPLEX_X2
 void mul2x2(complex const* left, complex const* right, complex* out)

--- a/src/qbdt/node.cpp
+++ b/src/qbdt/node.cpp
@@ -311,7 +311,7 @@ void QBdtNode::Normalize(bitLenInt depth)
         std::lock_guard<std::mutex> lock(b0->mtx);
 #endif
 
-        const real1_x nrm = (real1_x)sqrt((2 * norm(b0->scale)).to_double());
+        const real1_x nrm = (real1_x)sqrt(2 * (norm(b0->scale).to_double()));
 
         b0->Normalize(depth);
         b0->scale *= ONE_R1_X / nrm;
@@ -358,7 +358,7 @@ void QBdtNode::PopStateVector(bitLenInt depth, bitLenInt parDepth)
 #endif
         b0->PopStateVector(depth);
 
-        const real1_x nrm = (real1_x)(2 * norm(b0->scale));
+        const real1_x nrm = (real1_x)(2 * (norm(b0->scale).to_double()));
 
         if (nrm <= _qrack_qbdt_sep_thresh) {
             scale = ZERO_CMPLX;

--- a/src/qbdt/node_interface.cpp
+++ b/src/qbdt/node_interface.cpp
@@ -108,9 +108,9 @@ bool QBdtNodeInterface::isEqualBranch(QBdtNodeInterfacePtr r, const bool& b)
     // We can weight by square use_count() of each leaf, which should roughly
     // correspond to the number of branches that point to each node.
 
-    const real1 lWeight = (real1)(lLeaf.use_count() * lLeaf.use_count());
-    const real1 rWeight = (real1)(rLeaf.use_count() * rLeaf.use_count());
-    const complex nScale = (lWeight * lLeaf->scale + rWeight * rLeaf->scale) / (lWeight + rWeight);
+    const real1_x lWeight = (real1_x)(lLeaf.use_count() * lLeaf.use_count());
+    const real1_x rWeight = (real1_x)(rLeaf.use_count() * rLeaf.use_count());
+    const complex_x nScale = (lWeight * lLeaf->scale + rWeight * rLeaf->scale) / (lWeight + rWeight);
 
     if (IS_NODE_0(nScale)) {
         lLeaf->SetZero();
@@ -173,7 +173,7 @@ QBdtNodeInterfacePtr QBdtNodeInterface::RemoveSeparableAtDepth(
     }
 
     QBdtNodeInterfacePtr toRet = ShallowClone();
-    toRet->scale /= abs(toRet->scale);
+    toRet->scale /= (complex_x)sqrt((real1)(norm(toRet->scale).to_double()));
 
     if (!size) {
         branches[0U] = NULL;

--- a/src/qbdt/node_interface.cpp
+++ b/src/qbdt/node_interface.cpp
@@ -108,9 +108,12 @@ bool QBdtNodeInterface::isEqualBranch(QBdtNodeInterfacePtr r, const bool& b)
     // We can weight by square use_count() of each leaf, which should roughly
     // correspond to the number of branches that point to each node.
 
-    const real1_x lWeight = (real1_x)(lLeaf.use_count() * lLeaf.use_count());
-    const real1_x rWeight = (real1_x)(rLeaf.use_count() * rLeaf.use_count());
-    const complex_x nScale = (lWeight * lLeaf->scale + rWeight * rLeaf->scale) / (lWeight + rWeight);
+    const real1 lWeight = (real1)(lLeaf.use_count() * lLeaf.use_count());
+    const real1 rWeight = (real1)(rLeaf.use_count() * rLeaf.use_count());
+    const complex _nScale =
+        (lWeight * complexFixedToFloating(lLeaf->scale) + rWeight * complexFixedToFloating(rLeaf->scale)) /
+        (lWeight + rWeight);
+    const complex_x nScale = complex_x(real(_nScale), imag(_nScale));
 
     if (IS_NODE_0(nScale)) {
         lLeaf->SetZero();

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -292,7 +292,7 @@ real1_f QBdt::SumSqrDiff(QBdtPtr toCompare)
     if (randGlobalPhase) {
         real1_f lPhaseArg = FirstNonzeroPhase();
         real1_f rPhaseArg = toCompare->FirstNonzeroPhase();
-        root->scale *= std::polar(ONE_R1, (real1)(rPhaseArg - lPhaseArg));
+        root->scale *= (complex_x)std::polar(ONE_R1, (real1)(rPhaseArg - lPhaseArg));
     }
 
     _par_for(maxQPower, [&](const bitCapInt& i, const unsigned& cpu) {
@@ -833,14 +833,14 @@ void QBdt::FSim(real1_f theta, real1_f phi, bitLenInt qubit1, bitLenInt qubit2)
 
     const complex expIPhi = exp(complex(ZERO_R1, (real1)phi));
 
-    const real1_x sinThetaDiffNeg = ONE_R1 + sinTheta;
+    const real1_x sinThetaDiffNeg = ONE_R1_X + sinTheta;
     if ((sinThetaDiffNeg * sinThetaDiffNeg) <= FP_NORM_EPSILON) {
         ISwap(qubit1, qubit2);
         MCPhase(controls, ONE_CMPLX, expIPhi, qubit2);
         return;
     }
 
-    const real1_x sinThetaDiffPos = ONE_R1 - sinTheta;
+    const real1_x sinThetaDiffPos = ONE_R1_X - sinTheta;
     if ((sinThetaDiffPos * sinThetaDiffPos) <= FP_NORM_EPSILON) {
         IISwap(qubit1, qubit2);
         MCPhase(controls, ONE_CMPLX, expIPhi, qubit2);

--- a/src/qbdt/tree.cpp
+++ b/src/qbdt/tree.cpp
@@ -238,7 +238,7 @@ void QBdt::SetPermutation(bitCapInt initState, complex phaseFac)
     if (phaseFac == CMPLX_DEFAULT_ARG) {
         if (randGlobalPhase) {
             real1_f angle = Rand() * 2 * (real1_f)PI_R1;
-            phaseFac = complex((real1)cos(angle), (real1)sin(angle));
+            phaseFac = complex((real1_f)cos(angle), (real1_f)sin(angle));
         } else {
             phaseFac = ONE_CMPLX;
         }
@@ -316,7 +316,7 @@ complex QBdt::GetAmplitude(bitCapInt perm)
     FlushBuffers();
 
     QBdtNodeInterfacePtr leaf = root;
-    complex scale = leaf->scale;
+    complex_x scale = leaf->scale;
     for (bitLenInt j = 0U; j < qubitCount; ++j) {
         leaf = leaf->branches[SelectBit(perm, j)];
         if (!leaf) {
@@ -325,7 +325,7 @@ complex QBdt::GetAmplitude(bitCapInt perm)
         scale *= leaf->scale;
     }
 
-    return scale;
+    return complexFixedToFloating(scale);
 }
 
 bitLenInt QBdt::Compose(QBdtPtr toCopy, bitLenInt start)
@@ -434,12 +434,12 @@ real1_f QBdt::Prob(bitLenInt qubit)
 
     const bitCapInt qPower = pow2(qubit);
     const unsigned numCores = GetConcurrencyLevel();
-    std::map<QEnginePtr, real1> qiProbs;
-    std::unique_ptr<real1[]> oneChanceBuff(new real1[numCores]());
+    std::map<QEnginePtr, real1_x> qiProbs;
+    std::unique_ptr<real1_x[]> oneChanceBuff(new real1_x[numCores]());
 
     _par_for(qPower, [&](const bitCapInt& i, const unsigned& cpu) {
         QBdtNodeInterfacePtr leaf = root;
-        complex scale = leaf->scale;
+        complex_x scale = leaf->scale;
         for (bitLenInt j = 0U; j < qubit; ++j) {
             leaf = leaf->branches[SelectBit(i, j)];
             if (!leaf) {
@@ -455,12 +455,12 @@ real1_f QBdt::Prob(bitLenInt qubit)
         oneChanceBuff[cpu] += norm(scale * leaf->branches[1U]->scale);
     });
 
-    real1 oneChance = ZERO_R1;
+    real1_x oneChance = ZERO_R1;
     for (unsigned i = 0U; i < numCores; ++i) {
         oneChance += oneChanceBuff[i];
     }
 
-    return clampProb((real1_f)oneChance);
+    return clampProb((real1_f)(oneChance.to_double()));
 }
 
 real1_f QBdt::ProbAll(bitCapInt perm)
@@ -468,7 +468,7 @@ real1_f QBdt::ProbAll(bitCapInt perm)
     FlushBuffers();
 
     QBdtNodeInterfacePtr leaf = root;
-    complex scale = leaf->scale;
+    complex_x scale = leaf->scale;
 
     for (bitLenInt j = 0U; j < qubitCount; ++j) {
         leaf = leaf->branches[SelectBit(perm, j)];
@@ -478,7 +478,7 @@ real1_f QBdt::ProbAll(bitCapInt perm)
         scale *= leaf->scale;
     }
 
-    return clampProb((real1_f)norm(scale));
+    return clampProb((real1_f)(norm(scale).to_double()));
 }
 
 bool QBdt::ForceM(bitLenInt qubit, bool result, bool doForce, bool doApply)
@@ -541,13 +541,13 @@ bool QBdt::ForceM(bitLenInt qubit, bool result, bool doForce, bool doApply)
                 return;
             }
             b0->SetZero();
-            b1->scale /= abs(b1->scale);
+            b1->scale /= (complex_x)sqrt(norm(b1->scale).to_double());
         } else {
             if (IS_NODE_0(b0->scale)) {
                 b0->SetZero();
                 return;
             }
-            b0->scale /= abs(b0->scale);
+            b0->scale /= (complex_x)sqrt(norm(b0->scale).to_double());
             b1->SetZero();
         }
     });
@@ -571,7 +571,7 @@ bitCapInt QBdt::MAllOptionalCollapse(bool isCollapsing)
     }
 
     for (bitLenInt i = 0U; i < qubitCount; ++i) {
-        real1_f oneChance = clampProb((real1_f)norm(leaf->branches[1U]->scale));
+        real1_f oneChance = clampProb((real1_f)(norm(leaf->branches[1U]->scale).to_double()));
         bool bitResult;
         if (oneChance >= ONE_R1) {
             bitResult = true;
@@ -608,62 +608,47 @@ bitCapInt QBdt::MAllOptionalCollapse(bool isCollapsing)
     return result;
 }
 
-void QBdt::ApplySingle(const complex* mtrx, bitLenInt target)
+void QBdt::ApplySingle(const complex* _mtrx, bitLenInt target)
 {
     if (target >= qubitCount) {
         throw std::invalid_argument("QBdt::ApplySingle target parameter must be within allocated qubit bounds!");
     }
 
-    if (IS_NORM_0(mtrx[1U]) && IS_NORM_0(mtrx[2U]) && IS_NORM_0(mtrx[0U] - mtrx[3U]) &&
-        (randGlobalPhase || IS_NORM_0(ONE_CMPLX - mtrx[0U]))) {
+    if (IS_NORM_0(_mtrx[1U]) && IS_NORM_0(_mtrx[2U]) && IS_NORM_0(_mtrx[0U] - _mtrx[3U]) &&
+        (randGlobalPhase || IS_NORM_0(ONE_CMPLX - _mtrx[0U]))) {
         return;
     }
 
+    const complex_x mtrx[4U]{ (complex_x)_mtrx[0U], (complex_x)_mtrx[1U], (complex_x)_mtrx[2U], (complex_x)_mtrx[3U] };
+
     const bitCapInt qPower = pow2(target);
 
-#if ENABLE_COMPLEX_X2
-    const complex2 mtrxCol1(mtrx[0U], mtrx[2U]);
-    const complex2 mtrxCol2(mtrx[1U], mtrx[3U]);
-
-    const complex2 mtrxCol1Shuff = mtrxColShuff(mtrxCol1);
-    const complex2 mtrxCol2Shuff = mtrxColShuff(mtrxCol2);
-#endif
-
-    par_for_qbdt(qPower, target,
-#if ENABLE_COMPLEX_X2
-        [this, target, &mtrxCol1, &mtrxCol2, &mtrxCol1Shuff, &mtrxCol2Shuff](const bitCapInt& i) {
-#else
-        [this, target, mtrx](const bitCapInt& i) {
-#endif
-            QBdtNodeInterfacePtr leaf = root;
-            // Iterate to qubit depth.
-            for (bitLenInt j = 0U; j < target; ++j) {
-                leaf = leaf->branches[SelectBit(i, target - (j + 1U))];
-                if (!leaf) {
-                    return (bitCapInt)(pow2(target - j) - ONE_BCI);
-                }
+    par_for_qbdt(qPower, target, [this, target, mtrx](const bitCapInt& i) {
+        QBdtNodeInterfacePtr leaf = root;
+        // Iterate to qubit depth.
+        for (bitLenInt j = 0U; j < target; ++j) {
+            leaf = leaf->branches[SelectBit(i, target - (j + 1U))];
+            if (!leaf) {
+                return (bitCapInt)(pow2(target - j) - ONE_BCI);
             }
+        }
 
 #if ENABLE_QBDT_CPU_PARALLEL && ENABLE_PTHREAD
-            std::lock_guard<std::mutex> lock(leaf->mtx);
+        std::lock_guard<std::mutex> lock(leaf->mtx);
 #endif
 
-            if (!leaf->branches[0U] || !leaf->branches[1U]) {
-                leaf->SetZero();
-                return ZERO_BCI;
-            }
-
-#if ENABLE_COMPLEX_X2
-            leaf->Apply2x2(mtrxCol1, mtrxCol2, mtrxCol1Shuff, mtrxCol2Shuff, qubitCount - target);
-#else
-            leaf->Apply2x2(mtrx, qubitCount - target);
-#endif
-
+        if (!leaf->branches[0U] || !leaf->branches[1U]) {
+            leaf->SetZero();
             return ZERO_BCI;
-        });
+        }
+
+        leaf->Apply2x2(mtrx, qubitCount - target);
+
+        return ZERO_BCI;
+    });
 }
 
-void QBdt::ApplyControlledSingle(const complex* mtrx, std::vector<bitLenInt> controls, bitLenInt target, bool isAnti)
+void QBdt::ApplyControlledSingle(const complex* _mtrx, std::vector<bitLenInt> controls, bitLenInt target, bool isAnti)
 {
     if (target >= qubitCount) {
         throw std::invalid_argument(
@@ -673,9 +658,9 @@ void QBdt::ApplyControlledSingle(const complex* mtrx, std::vector<bitLenInt> con
     ThrowIfQbIdArrayIsBad(controls, qubitCount,
         "QBdt::ApplyControlledSingle parameter controls array values must be within allocated qubit bounds!");
 
-    const bool isPhase = IS_NORM_0(mtrx[1U]) && IS_NORM_0(mtrx[2U]) &&
-        (isAnti ? IS_NORM_0(ONE_CMPLX - mtrx[3U]) : IS_NORM_0(ONE_CMPLX - mtrx[0U]));
-    if (isPhase && IS_NORM_0(ONE_CMPLX - mtrx[0U]) && IS_NORM_0(ONE_CMPLX - mtrx[3U])) {
+    const bool isPhase = IS_NORM_0(_mtrx[1U]) && IS_NORM_0(_mtrx[2U]) &&
+        (isAnti ? IS_NORM_0(ONE_CMPLX - _mtrx[3U]) : IS_NORM_0(ONE_CMPLX - _mtrx[0U]));
+    if (isPhase && IS_NORM_0(ONE_CMPLX - _mtrx[0U]) && IS_NORM_0(ONE_CMPLX - _mtrx[3U])) {
         return;
     }
 
@@ -685,13 +670,15 @@ void QBdt::ApplyControlledSingle(const complex* mtrx, std::vector<bitLenInt> con
         if (!isPhase) {
             // We need the target at back, for QBdt, if this isn't symmetric.
             Swap(target, controls.back());
-            ApplyControlledSingle(mtrx, controls, target, isAnti);
+            ApplyControlledSingle(_mtrx, controls, target, isAnti);
             Swap(target, controls.back());
 
             return;
         }
         // Otherwise, the gate is symmetric in target and controls, so we can continue.
     }
+
+    const complex_x mtrx[4U]{ (complex_x)_mtrx[0U], (complex_x)_mtrx[1U], (complex_x)_mtrx[2U], (complex_x)_mtrx[3U] };
 
     const bitCapInt qPower = pow2(target);
     bitCapInt controlMask = ZERO_BCI;
@@ -701,52 +688,34 @@ void QBdt::ApplyControlledSingle(const complex* mtrx, std::vector<bitLenInt> con
     }
     const bitCapInt controlPerm = isAnti ? ZERO_BCI : controlMask;
 
-#if ENABLE_COMPLEX_X2
-    const complex2 mtrxCol1(mtrx[0U], mtrx[2U]);
-    const complex2 mtrxCol2(mtrx[1U], mtrx[3U]);
+    par_for_qbdt(qPower, target, [this, controlMask, controlPerm, target, mtrx](const bitCapInt& i) {
+        if (bi_compare((i & controlMask), controlPerm) != 0) {
+            return controlMask - ONE_BCI;
+        }
 
-    const complex2 mtrxCol1Shuff = mtrxColShuff(mtrxCol1);
-    const complex2 mtrxCol2Shuff = mtrxColShuff(mtrxCol2);
-#endif
-
-    par_for_qbdt(qPower, target,
-#if ENABLE_COMPLEX_X2
-        [this, controlMask, controlPerm, target, &mtrxCol1, &mtrxCol2, &mtrxCol1Shuff, &mtrxCol2Shuff](
-            const bitCapInt& i) {
-#else
-        [this, controlMask, controlPerm, target, mtrx](const bitCapInt& i) {
-#endif
-            if (bi_compare((i & controlMask), controlPerm) != 0) {
-                return controlMask - ONE_BCI;
+        QBdtNodeInterfacePtr leaf = root;
+        // Iterate to qubit depth.
+        for (bitLenInt j = 0U; j < target; ++j) {
+            leaf = leaf->branches[SelectBit(i, target - (j + 1U))];
+            if (!leaf) {
+                // WARNING: Mutates loop control variable!
+                return (bitCapInt)(pow2(target - j) - ONE_BCI);
             }
-
-            QBdtNodeInterfacePtr leaf = root;
-            // Iterate to qubit depth.
-            for (bitLenInt j = 0U; j < target; ++j) {
-                leaf = leaf->branches[SelectBit(i, target - (j + 1U))];
-                if (!leaf) {
-                    // WARNING: Mutates loop control variable!
-                    return (bitCapInt)(pow2(target - j) - ONE_BCI);
-                }
-            }
+        }
 
 #if ENABLE_QBDT_CPU_PARALLEL && ENABLE_PTHREAD
-            std::lock_guard<std::mutex> lock(leaf->mtx);
+        std::lock_guard<std::mutex> lock(leaf->mtx);
 #endif
 
-            if (!leaf->branches[0U] || !leaf->branches[1U]) {
-                leaf->SetZero();
-                return ZERO_BCI;
-            }
-
-#if ENABLE_COMPLEX_X2
-            leaf->Apply2x2(mtrxCol1, mtrxCol2, mtrxCol1Shuff, mtrxCol2Shuff, qubitCount - target);
-#else
-            leaf->Apply2x2(mtrx, qubitCount - target);
-#endif
-
+        if (!leaf->branches[0U] || !leaf->branches[1U]) {
+            leaf->SetZero();
             return ZERO_BCI;
-        });
+        }
+
+        leaf->Apply2x2(mtrx, qubitCount - target);
+
+        return ZERO_BCI;
+    });
 }
 
 void QBdt::Mtrx(const complex* mtrx, bitLenInt target)
@@ -855,7 +824,7 @@ void QBdt::FSim(real1_f theta, real1_f phi, bitLenInt qubit1, bitLenInt qubit2)
     }
 
     const std::vector<bitLenInt> controls{ qubit1 };
-    real1 sinTheta = (real1)sin(theta);
+    real1_x sinTheta = (real1_x)sin(theta);
 
     if ((sinTheta * sinTheta) <= FP_NORM_EPSILON) {
         MCPhase(controls, ONE_CMPLX, exp(complex(ZERO_R1, (real1)phi)), qubit2);
@@ -864,14 +833,14 @@ void QBdt::FSim(real1_f theta, real1_f phi, bitLenInt qubit1, bitLenInt qubit2)
 
     const complex expIPhi = exp(complex(ZERO_R1, (real1)phi));
 
-    const real1 sinThetaDiffNeg = ONE_R1 + sinTheta;
+    const real1_x sinThetaDiffNeg = ONE_R1 + sinTheta;
     if ((sinThetaDiffNeg * sinThetaDiffNeg) <= FP_NORM_EPSILON) {
         ISwap(qubit1, qubit2);
         MCPhase(controls, ONE_CMPLX, expIPhi, qubit2);
         return;
     }
 
-    const real1 sinThetaDiffPos = ONE_R1 - sinTheta;
+    const real1_x sinThetaDiffPos = ONE_R1 - sinTheta;
     if ((sinThetaDiffPos * sinThetaDiffPos) <= FP_NORM_EPSILON) {
         IISwap(qubit1, qubit2);
         MCPhase(controls, ONE_CMPLX, expIPhi, qubit2);


### PR DESCRIPTION
We had a "false start" with fixed-point math: I added the relevant header but did not properly call its API the way I thought I had. Addressing this issue, it seems that fixed-point state vector simulation might be difficult and not necessarily better than floating-point. However, QBDD is an ideal candidate for fixed-point math, since branch pairs always exist in sets of two whose overall sum norm is 1, implying an absolute scale of 0.5 (or sqrt(0.5)) for all QBDD math.