### PR TITLE
QInterfaceNoisy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.9)
-project (Qrack VERSION 9.8.3 DESCRIPTION "High Performance Quantum Bit Simulation" LANGUAGES CXX)
+project (Qrack VERSION 9.9.0 DESCRIPTION "High Performance Quantum Bit Simulation" LANGUAGES CXX)
 
 # Installation commands
 include (GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library (qrack STATIC
     src/qstabilizerhybrid.cpp
     src/qcircuit.cpp
     src/qtensornetwork.cpp
+    src/qinterface_noisy.cpp
     )
 set_property(TARGET qrack PROPERTY POSITION_INDEPENDENT_CODE ON)
 if (ENABLE_PTHREAD AND ENABLE_QUNIT_CPU_PARALLEL)
@@ -389,6 +390,7 @@ install (FILES
     include/qengine_cuda.hpp
     include/qtensornetwork.hpp
     include/qinterface.hpp
+    include/qinterface_noisy.hpp
     include/qalu.hpp
     include/qparity.hpp
     include/qneuron.hpp

--- a/README.md
+++ b/README.md
@@ -250,12 +250,14 @@ Set the maximum allowed allocation (in MB) for the global OpenCL pool with `QRAC
 
 Note that this controls total direct Qrack OpenCL buffer allocation, not total Qrack library allocation. Total OpenCL buffer allocation is **not** fully indicative of total library allocation.
 
-## Approximation options
+## Approximation and noise options
 `QUnit` can optionally round qubit subsystems proactively or on-demand to the nearest single or double qubit eigenstate with the `QRACK_QUNIT_SEPARABILITY_THRESHOLD=[0.0 - 1.0]` environment variable, with a value between `0.0` and `1.0`. When trying to find separable subsystems, Qrack will start by making 3-axis (independent or conditional) probability measurements. Based on the probability measurements, under the assumption that the state _is_ separable, an inverse state preparation to |0> procedure is fixed. If inverse state preparation would bring any single qubit Bloch sphere projection within parameter range of the edge of the Bloch sphere, (with unit length, `1.0`,) then the subsystem will be rounded to that state, normalized, and then "uncomputed" with the corresponding (forward) state preparation, effectively "hyperpolarizing" one and two qubit separable substates by replacing entanglement with local qubit Bloch sphere extent. (If 3-axis probability is _not_ within rounding range, nothing is done directly to the substate.)
 
 Similarly functionality to above is available for `QBdt` with `QRACK_QBDT_SEPARABILITY_THRESHOLD=[0.0 - 0.5]`. In the case of this parameter, any branch with less than the parameter value for probability is rounded to 0, and its partner branch is renormalized to unit length. This same value is also used for branch equality comparison.
 
 Environment variable `QRACK_NONCLIFFORD_ROUNDING_THRESHOLD` sets the non-Clifford phase gate magnitude, as a fraction of `T` gate phase angle, (from the closest Clifford state Bloch sphere orientation,) that will be rounded to 0 in terminal measurement and sampling operations. (For `0`/default value, all non-Clifford phase gates are exactly preserved.)
+
+For single-qubit depolarizing noise channels, `QInterfaceNoisy` exposes environment variable `QRACK_GATE_DEPOLARIZATION`, which is a per-gate, single-qubit (applied to all qubits in gate) noise parameter for depolarizing noise, typically taking a floating-point value between `0` and `1`.
 
 ## Vectorization optimization
 

--- a/doxygen.config
+++ b/doxygen.config
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Qrack"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 9.8
+PROJECT_NUMBER         = 9.9
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -343,6 +343,7 @@ MICROSOFT_QUANTUM_DECL void SetSdrp(_In_ uintq sid, _In_ double sdrp);
 MICROSOFT_QUANTUM_DECL void SetNcrp(_In_ uintq sid, _In_ double ncrp);
 MICROSOFT_QUANTUM_DECL void SetReactiveSeparate(_In_ uintq sid, _In_ bool irs);
 MICROSOFT_QUANTUM_DECL void SetTInjection(_In_ uintq sid, _In_ bool iti);
+MICROSOFT_QUANTUM_DECL void SetNoiseParameter(_In_ uintq sid, _In_ double np);
 
 #if !(FPPOW < 6 && !defined(ENABLE_COMPLEX_X2))
 MICROSOFT_QUANTUM_DECL void TimeEvolve(_In_ uintq sid, _In_ double t, _In_ uintq n,

--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -38,7 +38,7 @@ extern "C" {
 // non-quantum
 MICROSOFT_QUANTUM_DECL int get_error(_In_ uintq sid);
 MICROSOFT_QUANTUM_DECL uintq init_count_type(_In_ uintq q, _In_ bool tn, _In_ bool md, _In_ bool sd, _In_ bool sh,
-    _In_ bool bdt, _In_ bool pg, _In_ bool zxf, _In_ bool hy, _In_ bool oc, _In_ bool dm);
+    _In_ bool bdt, _In_ bool pg, _In_ bool nw, _In_ bool hy, _In_ bool oc, _In_ bool dm);
 MICROSOFT_QUANTUM_DECL uintq init_count(_In_ uintq q, _In_ bool dm);
 MICROSOFT_QUANTUM_DECL uintq init_count_pager(_In_ uintq q, _In_ bool dm);
 MICROSOFT_QUANTUM_DECL uintq init() { return init_count(0, false); }

--- a/include/qfactory.hpp
+++ b/include/qfactory.hpp
@@ -38,6 +38,8 @@
 #include "qbdthybrid.hpp"
 #endif
 
+#include "qinterface_noisy.hpp"
+
 namespace Qrack {
 
 /** Factory method to create specific engine implementations. */
@@ -83,6 +85,8 @@ QInterfacePtr CreateQuantumInterface(
 #endif
     case QINTERFACE_CPU:
         return std::make_shared<QEngineCPU>(args...);
+    case QINTERFACE_NOISY:
+        return std::make_shared<QInterfaceNoisy>(engines, args...);
     default:
         throw std::invalid_argument("CreateQuantumInterface received a request to create a nonexistent type instance!");
     }
@@ -129,6 +133,8 @@ QInterfacePtr CreateQuantumInterface(QInterfaceEngine engine1, QInterfaceEngine 
 #endif
     case QINTERFACE_CPU:
         return std::make_shared<QEngineCPU>(args...);
+    case QINTERFACE_NOISY:
+        return std::make_shared<QInterfaceNoisy>(engines, args...);
     default:
         throw std::invalid_argument("CreateQuantumInterface received a request to create a nonexistent type instance!");
     }
@@ -171,6 +177,8 @@ template <typename... Ts> QInterfacePtr CreateQuantumInterface(QInterfaceEngine 
 #endif
     case QINTERFACE_CPU:
         return std::make_shared<QEngineCPU>(args...);
+    case QINTERFACE_NOISY:
+        return std::make_shared<QInterfaceNoisy>(engines, args...);
     default:
         throw std::invalid_argument("CreateQuantumInterface received a request to create a nonexistent type instance!");
     }
@@ -237,6 +245,8 @@ template <typename... Ts> QInterfacePtr CreateQuantumInterface(std::vector<QInte
 #endif
     case QINTERFACE_CPU:
         return std::make_shared<QEngineCPU>(args...);
+    case QINTERFACE_NOISY:
+        return std::make_shared<QInterfaceNoisy>(engines, args...);
     default:
         throw std::invalid_argument("CreateQuantumInterface received a request to create a nonexistent type instance!");
     }
@@ -248,7 +258,8 @@ template <typename... Ts> QInterfacePtr CreateQuantumInterface(std::vector<QInte
 #define DEVICE_COUNT (CUDAEngine::Instance().GetDeviceCount())
 #endif
 template <typename... Ts>
-QInterfacePtr CreateArrangedLayers(bool md, bool sd, bool sh, bool bdt, bool pg, bool tn, bool hy, bool oc, Ts... args)
+QInterfacePtr CreateArrangedLayersFull(
+    bool nw, bool md, bool sd, bool sh, bool bdt, bool pg, bool tn, bool hy, bool oc, Ts... args)
 {
 #if ENABLE_OPENCL || ENABLE_CUDA
     bool isOcl = oc && (DEVICE_COUNT > 0);
@@ -294,6 +305,10 @@ QInterfacePtr CreateArrangedLayers(bool md, bool sd, bool sh, bool bdt, bool pg,
         simulatorType.push_back(QINTERFACE_TENSOR_NETWORK);
     }
 
+    if (nw) {
+        simulatorType.push_back(QINTERFACE_NOISY);
+    }
+
     // (...then reverse:)
     std::reverse(simulatorType.begin(), simulatorType.end());
 
@@ -314,6 +329,11 @@ QInterfacePtr CreateArrangedLayers(bool md, bool sd, bool sh, bool bdt, bool pg,
     }
 
     return CreateQuantumInterface(simulatorType, args...);
+}
+template <typename... Ts>
+QInterfacePtr CreateArrangedLayers(bool md, bool sd, bool sh, bool bdt, bool pg, bool tn, bool hy, bool oc, Ts... args)
+{
+    return CreateArrangedLayersFull(false, md, sd, sh, bdt, pg, tn, hy, oc, args...);
 }
 
 } // namespace Qrack

--- a/include/qfactory.hpp
+++ b/include/qfactory.hpp
@@ -178,7 +178,7 @@ template <typename... Ts> QInterfacePtr CreateQuantumInterface(QInterfaceEngine 
     case QINTERFACE_CPU:
         return std::make_shared<QEngineCPU>(args...);
     case QINTERFACE_NOISY:
-        return std::make_shared<QInterfaceNoisy>(engines, args...);
+        return std::make_shared<QInterfaceNoisy>(args...);
     default:
         throw std::invalid_argument("CreateQuantumInterface received a request to create a nonexistent type instance!");
     }

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -102,9 +102,14 @@ enum QInterfaceEngine {
     QINTERFACE_QUNIT_CLIFFORD,
 
     /**
-     * Circuit-simplification layer, with (optional) recourse to cuTensorNetwork
+     * Circuit-simplification layer
      */
     QINTERFACE_TENSOR_NETWORK,
+
+    /**
+     * Noisy wrapper layer
+     */
+    QINTERFACE_NOISY,
 
 #if ENABLE_OPENCL || ENABLE_CUDA
     QINTERFACE_OPTIMAL_SCHROEDINGER = QINTERFACE_QPAGER,

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -2915,6 +2915,18 @@ public:
      * helps.
      */
     virtual bool GetTInjection() { return false; }
+    /**
+     *  Set the noise level option (only for a noisy interface)
+     *
+     *  If this is a QInterfaceNoisy, adjust the noise level per gate.
+     */
+    virtual void SetNoiseParameter(real1_f lambda) {}
+    /**
+     *  Get the noise level option (only for a noisy interface)
+     *
+     *  If this is a QInterfaceNoisy, return the noise level per gate.
+     */
+    virtual real1_f GetNoiseParameter() { return ZERO_R1_F; }
 
     /**
      *  Clone this QInterface

--- a/include/qinterface_noisy.hpp
+++ b/include/qinterface_noisy.hpp
@@ -73,7 +73,8 @@ public:
         engine = o->engine->Clone();
     }
 
-    void SetNoiseLevel(real1_f lambda) { noiseParam = lambda; }
+    void SetNoiseParameter(real1_f lambda) { noiseParam = lambda; }
+    real1_f GetNoiseParameter() { return noiseParam; }
 
     double GetUnitaryFidelity() { return (double)exp(logFidelity); }
     void ResetUnitaryFidelity() { logFidelity = 0.0; }

--- a/include/qinterface_noisy.hpp
+++ b/include/qinterface_noisy.hpp
@@ -64,7 +64,7 @@ public:
         , engine(o->engine)
         , engines(o->engines)
     {
-        // Intentionally left blank
+        engine = o->engine->Clone();
     }
 
     void SetNoiseLevel(real1_f lambda) { noiseParam = lambda; }
@@ -271,9 +271,7 @@ public:
 
     QInterfacePtr Clone()
     {
-        QInterfaceNoisyPtr c = std::make_shared<QInterfaceNoisy>(this);
-        c->engine = engine->Clone();
-        return c;
+        return std::make_shared<QInterfaceNoisy>(this);
     }
 
     void SetDevice(int64_t dID) { engine->SetDevice(dID); }

--- a/include/qinterface_noisy.hpp
+++ b/include/qinterface_noisy.hpp
@@ -38,6 +38,9 @@ protected:
             n = (real1_f)std::stof(std::string(getenv("QRACK_GATE_DEPOLARIZATION")));
         }
 #endif
+        if (n <= ZERO_R1_F) {
+            return;
+        }
         engine->DepolarizingChannelWeak1Qb(qb, n);
         if ((n + FP_NORM_EPSILON) >= ONE_R1_F) {
             logFidelity = -1 * std::numeric_limits<float>::infinity();

--- a/include/qinterface_noisy.hpp
+++ b/include/qinterface_noisy.hpp
@@ -35,432 +35,366 @@ typedef std::shared_ptr<QInterfaceNoisy> QInterfaceNoisyPtr;
 /**
  * A "Qrack::QInterfaceNoisy" that wraps any other QInterface with a simple noise model
  */
-
-namespace Qrack {
-
-    class QUnit;
-    typedef std::shared_ptr<QUnit> QUnitPtr;
-
 #if ENABLE_ALU
-    class QInterfaceNoisy : public QAlu, public QParity, public QInterface {
+class QInterfaceNoisy : public QAlu, public QParity, public QInterface {
 #else
-    class QInterfaceNoisy : public QParity, public QInterface {
+class QInterfaceNoisy : public QParity, public QInterface {
 #endif
-    protected:
-        real1_f noiseParam;
-        QInterfacePtr engine;
-        std::vector<QInterfaceEngine> engines;
+protected:
+    real1_f noiseParam;
+    QInterfacePtr engine;
+    std::vector<QInterfaceEngine> engines;
 
-    public:
-        QInterfaceNoisy(bitLenInt qBitCount, bitCapInt initState = ZERO_BCI, qrack_rand_gen_ptr rgp = nullptr,
-            complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
-            bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
-            real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {}, bitLenInt qubitThreshold = 0U,
-            real1_f separation_thresh = FP_NORM_EPSILON_F)
-            : QInterfaceNoisy({ QINTERFACE_TENSOR_NETWORK }, qBitCount, initState, rgp, phaseFac, doNorm,
-                  randomGlobalPhase, useHostMem, deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, devList,
-                  qubitThreshold, separation_thresh)
-            {
-                // Intentionally left blank;
-            }
+public:
+    QInterfaceNoisy(bitLenInt qBitCount, bitCapInt initState = ZERO_BCI, qrack_rand_gen_ptr rgp = nullptr,
+        complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
+        bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
+        real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {}, bitLenInt qubitThreshold = 0U,
+        real1_f separation_thresh = FP_NORM_EPSILON_F)
+        : QInterfaceNoisy({ QINTERFACE_TENSOR_NETWORK }, qBitCount, initState, rgp, phaseFac, doNorm, randomGlobalPhase,
+              useHostMem, deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold,
+              separation_thresh)
+    {
+        // Intentionally left blank;
+    }
 
-        QInterfaceNoisy(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState = ZERO_BCI,
-            qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
-            bool randomGlobalPhase = true, bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true,
-            bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {},
-            bitLenInt qubitThreshold = 0U, real1_f separation_thresh = FP_NORM_EPSILON_F);
+    QInterfaceNoisy(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState = ZERO_BCI,
+        qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
+        bool randomGlobalPhase = true, bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true,
+        bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {},
+        bitLenInt qubitThreshold = 0U, real1_f separation_thresh = FP_NORM_EPSILON_F);
 
-        void SetNoiseLevel(real1_f lambda) { noiseParam = lambda; }
+    QInterfaceNoisy(QInterfaceNoisy* o)
+        : noiseParam(o->noiseParam)
+        , engine(o->engine)
+        , engines(o->engines)
+    {
+        // Intentionally left blank
+    }
 
-        void SetQubitCount(bitLenInt qb)
-        {
-            QInterface::SetQubitCount(qb);
-            engine->SetQubitCount(qb);
-        }
+    void SetNoiseLevel(real1_f lambda) { noiseParam = lambda; }
 
-        bool isOpenCL() { return engine->isOpenCL(); }
+    void SetQubitCount(bitLenInt qb)
+    {
+        QInterface::SetQubitCount(qb);
+        engine->SetQubitCount(qb);
+    }
 
-        void SetConcurrency(uint32_t threadCount)
-        {
-            QInterface::SetConcurrency(threadCount);
-            engine->SetConcurrency(GetConcurrencyLevel());
-        }
+    bool isOpenCL() { return engine->isOpenCL(); }
 
-        real1_f ProbReg(bitLenInt start, bitLenInt length, bitCapInt permutation)
-        {
-            return engine->ProbReg(start, length, permutation);
-        }
+    void SetConcurrency(uint32_t threadCount)
+    {
+        QInterface::SetConcurrency(threadCount);
+        engine->SetConcurrency(GetConcurrencyLevel());
+    }
 
-        using QInterface::Compose;
-        bitLenInt Compose(QInterfaceNoisyPtr toCopy)
-        {
-            SetQubitCount(qubitCount + toCopy->qubitCount);
-            return engine->Compose(toCopy->engine);
-        }
-        bitLenInt Compose(QInterfacePtr toCopy) { return Compose(std::dynamic_pointer_cast<QInterfaceNoisy>(toCopy)); }
-        bitLenInt Compose(QInterfaceNoisyPtr toCopy, bitLenInt start)
-        {
-            SetQubitCount(qubitCount + toCopy->qubitCount);
-            return engine->Compose(toCopy->engine, start);
-        }
-        bitLenInt Compose(QInterfacePtr toCopy, bitLenInt start)
-        {
-            return Compose(std::dynamic_pointer_cast<QInterfaceNoisy>(toCopy), start);
-        }
-        bitLenInt ComposeNoClone(QInterfaceNoisyPtr toCopy)
-        {
-            SetQubitCount(qubitCount + toCopy->qubitCount);
-            return engine->ComposeNoClone(toCopy->engine);
-        }
-        bitLenInt ComposeNoClone(QInterfacePtr toCopy)
-        {
-            return ComposeNoClone(std::dynamic_pointer_cast<QInterfaceNoisy>(toCopy));
-        }
-        using QInterface::Decompose;
-        void Decompose(bitLenInt start, QInterfacePtr dest)
-        {
-            Decompose(start, std::dynamic_pointer_cast<QInterfaceNoisy>(dest));
-        }
-        bool TryDecompose(bitLenInt start, QInterfacePtr dest, real1_f error_tol = TRYDECOMPOSE_EPSILON)
-        {
-            return TryDecompose(start, std::dynamic_pointer_cast<QInterfaceNoisy>(dest), error_tol);
-        }
-        void Decompose(bitLenInt start, QInterfaceNoisyPtr dest)
-        {
-            engine->Decompose(start, dest->engine);
-            SetQubitCount(qubitCount - dest->GetQubitCount());
-        }
-        void Dispose(bitLenInt start, bitLenInt length)
-        {
-            engine->Dispose(start, length);
-            SetQubitCount(qubitCount - length);
-        }
-        void Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPerm)
-        {
-            engine->Dispose(start, length, disposedPerm);
-            SetQubitCount(qubitCount - length);
-        }
+    real1_f ProbReg(bitLenInt start, bitLenInt length, bitCapInt permutation)
+    {
+        return engine->ProbReg(start, length, permutation);
+    }
 
-        using QInterface::Allocate;
-        bitLenInt Allocate(bitLenInt start, bitLenInt length)
-        {
-            if (!length) {
-                return start;
-            }
+    using QInterface::Compose;
+    bitLenInt Compose(QInterfaceNoisyPtr toCopy)
+    {
+        SetQubitCount(qubitCount + toCopy->qubitCount);
+        return engine->Compose(toCopy->engine);
+    }
+    bitLenInt Compose(QInterfacePtr toCopy) { return Compose(std::dynamic_pointer_cast<QInterfaceNoisy>(toCopy)); }
+    bitLenInt Compose(QInterfaceNoisyPtr toCopy, bitLenInt start)
+    {
+        SetQubitCount(qubitCount + toCopy->qubitCount);
+        return engine->Compose(toCopy->engine, start);
+    }
+    bitLenInt Compose(QInterfacePtr toCopy, bitLenInt start)
+    {
+        return Compose(std::dynamic_pointer_cast<QInterfaceNoisy>(toCopy), start);
+    }
+    bitLenInt ComposeNoClone(QInterfaceNoisyPtr toCopy)
+    {
+        SetQubitCount(qubitCount + toCopy->qubitCount);
+        return engine->ComposeNoClone(toCopy->engine);
+    }
+    bitLenInt ComposeNoClone(QInterfacePtr toCopy)
+    {
+        return ComposeNoClone(std::dynamic_pointer_cast<QInterfaceNoisy>(toCopy));
+    }
+    using QInterface::Decompose;
+    void Decompose(bitLenInt start, QInterfacePtr dest)
+    {
+        Decompose(start, std::dynamic_pointer_cast<QInterfaceNoisy>(dest));
+    }
+    bool TryDecompose(bitLenInt start, QInterfacePtr dest, real1_f error_tol = TRYDECOMPOSE_EPSILON)
+    {
+        return TryDecompose(start, std::dynamic_pointer_cast<QInterfaceNoisy>(dest), error_tol);
+    }
+    void Decompose(bitLenInt start, QInterfaceNoisyPtr dest)
+    {
+        engine->Decompose(start, dest->engine);
+        SetQubitCount(qubitCount - dest->GetQubitCount());
+    }
+    void Dispose(bitLenInt start, bitLenInt length)
+    {
+        engine->Dispose(start, length);
+        SetQubitCount(qubitCount - length);
+    }
+    void Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPerm)
+    {
+        engine->Dispose(start, length, disposedPerm);
+        SetQubitCount(qubitCount - length);
+    }
 
-            QInterfaceNoisyPtr nQubits = std::make_shared<QInterfaceNoisy>(length, ZERO_BCI, rand_generator,
-                phaseFactor, doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse,
-                (real1_f)amplitudeFloor, deviceIDs, gpuThresholdQubits, separabilityThreshold);
-            nQubits->SetConcurrency(GetConcurrencyLevel());
+    bool TryDecompose(bitLenInt start, QInterfaceNoisyPtr dest, real1_f error_tol = TRYDECOMPOSE_EPSILON)
+    {
+        const bitLenInt nQubitCount = qubitCount - dest->GetQubitCount();
+        const bool result = engine->TryDecompose(start, dest->engine, error_tol);
+        if (result) {
+            SetQubitCount(nQubitCount);
+        }
+        return result;
+    }
 
-            return Compose(nQubits, start);
-        }
+    void SetQuantumState(const complex* inputState) { engine->SetQuantumState(inputState); }
+    void GetQuantumState(complex* outputState) { engine->GetQuantumState(outputState); }
+    void GetProbs(real1* outputProbs) { engine->GetProbs(outputProbs); }
+    complex GetAmplitude(bitCapInt perm) { return engine->GetAmplitude(perm); }
+    void SetAmplitude(bitCapInt perm, complex amp) { engine->SetAmplitude(perm, amp); }
+    void SetPermutation(bitCapInt perm, complex phaseFac = CMPLX_DEFAULT_ARG)
+    {
+        engine->SetPermutation(perm, phaseFac);
+    }
 
-        bool TryDecompose(bitLenInt start, QInterfaceNoisyPtr dest, real1_f error_tol = TRYDECOMPOSE_EPSILON)
-        {
-            const bitLenInt nQubitCount = qubitCount - dest->GetQubitCount();
-            const bool result = engine->TryDecompose(start, dest->engine, error_tol);
-            if (result) {
-                SetQubitCount(nQubitCount);
-            }
-            return result;
-        }
+    void Mtrx(const complex* mtrx, bitLenInt qubitIndex) { engine->Mtrx(mtrx, qubitIndex); }
+    void Phase(complex topLeft, complex bottomRight, bitLenInt qubitIndex)
+    {
+        engine->Phase(topLeft, bottomRight, qubitIndex);
+    }
+    void Invert(complex topRight, complex bottomLeft, bitLenInt qubitIndex)
+    {
+        engine->Invert(topRight, bottomLeft, qubitIndex);
+    }
+    void MCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
+    {
+        engine->MCMtrx(controls, mtrx, target);
+    }
+    void MACMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
+    {
+        engine->MACMtrx(controls, mtrx, target);
+    }
 
-        void SetQuantumState(const complex* inputState) { engine->SetQuantumState(inputState); }
-        void GetQuantumState(complex* outputState) { engine->GetQuantumState(outputState); }
-        void GetProbs(real1* outputProbs) { engine->GetProbs(outputProbs); }
-        complex GetAmplitude(bitCapInt perm) { return engine->GetAmplitude(perm); }
-        void SetAmplitude(bitCapInt perm, complex amp) { engine->SetAmplitude(perm, amp); }
-        void SetPermutation(bitCapInt perm, complex phaseFac = CMPLX_DEFAULT_ARG)
-        {
-            engine->SetPermutation(perm, phaseFac);
-        }
+    using QInterface::UniformlyControlledSingleBit;
+    void UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls, bitLenInt qubitIndex,
+        const complex* mtrxs, const std::vector<bitCapInt> mtrxSkipPowers, bitCapInt mtrxSkipValueMask)
+    {
+        engine->UniformlyControlledSingleBit(controls, qubitIndex, mtrxs, mtrxSkipPowers, mtrxSkipValueMask);
+    }
 
-        void Mtrx(const complex* mtrx, bitLenInt qubitIndex) { engine->Mtrx(mtrx, qubitIndex); }
-        void Phase(complex topLeft, complex bottomRight, bitLenInt qubitIndex)
-        {
-            engine->Phase(topLeft, bottomRight, qubitIndex);
-        }
-        void Invert(complex topRight, complex bottomLeft, bitLenInt qubitIndex)
-        {
-            engine->Invert(topRight, bottomLeft, qubitIndex);
-        }
-        void MCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
-        {
-            engine->MCMtrx(controls, mtrx, target);
-        }
-        void MACMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
-        {
-            engine->MACMtrx(controls, mtrx, target);
-        }
+    void XMask(bitCapInt mask) { engine->XMask(mask); }
+    void PhaseParity(real1_f radians, bitCapInt mask) { engine->PhaseParity(radians, mask); }
 
-        using QInterface::UniformlyControlledSingleBit;
-        void UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls, bitLenInt qubitIndex,
-            const complex* mtrxs, const std::vector<bitCapInt> mtrxSkipPowers, bitCapInt mtrxSkipValueMask)
-        {
-            engine->UniformlyControlledSingleBit(controls, qubitIndex, mtrxs, mtrxSkipPowers, mtrxSkipValueMask);
-        }
+    real1_f CProb(bitLenInt control, bitLenInt target) { return engine->CProb(control, target); }
+    real1_f ACProb(bitLenInt control, bitLenInt target) { return engine->ACProb(control, target); }
 
-        void XMask(bitCapInt mask) { engine->XMask(mask); }
-        void PhaseParity(real1_f radians, bitCapInt mask) { engine->PhaseParity(radians, mask); }
+    void CSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
+    {
+        engine->CSwap(controls, qubit1, qubit2);
+    }
+    void AntiCSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
+    {
+        engine->AntiCSwap(controls, qubit1, qubit2);
+    }
+    void CSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
+    {
+        engine->CSqrtSwap(controls, qubit1, qubit2);
+    }
+    void AntiCSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
+    {
+        engine->AntiCSqrtSwap(controls, qubit1, qubit2);
+    }
+    void CISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
+    {
+        engine->CISqrtSwap(controls, qubit1, qubit2);
+    }
+    void AntiCISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
+    {
+        engine->AntiCISqrtSwap(controls, qubit1, qubit2);
+    }
 
-        real1_f CProb(bitLenInt control, bitLenInt target) { return engine->CProb(control, target); }
-        real1_f ACProb(bitLenInt control, bitLenInt target) { return engine->ACProb(control, target); }
-
-        void CSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
-        {
-            engine->CSwap(controls, qubit1, qubit2);
-        }
-        void AntiCSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
-        {
-            engine->AntiCSwap(controls, qubit1, qubit2);
-        }
-        void CSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
-        {
-            engine->CSqrtSwap(controls, qubit1, qubit2);
-        }
-        void AntiCSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
-        {
-            engine->AntiCSqrtSwap(controls, qubit1, qubit2);
-        }
-        void CISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
-        {
-            engine->CISqrtSwap(controls, qubit1, qubit2);
-        }
-        void AntiCISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
-        {
-            engine->AntiCISqrtSwap(controls, qubit1, qubit2);
-        }
-
-        bool ForceM(bitLenInt qubit, bool result, bool doForce = true, bool doApply = true)
-        {
-            return engine->ForceM(qubit, result, doForce, doApply);
-        }
+    bool ForceM(bitLenInt qubit, bool result, bool doForce = true, bool doApply = true)
+    {
+        return engine->ForceM(qubit, result, doForce, doApply);
+    }
 
 #if ENABLE_ALU
-        void INC(bitCapInt toAdd, bitLenInt start, bitLenInt length) { engine->INC(toAdd, start, length); }
-        void CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const std::vector<bitLenInt>& controls)
-        {
-            engine->CINC(toAdd, inOutStart, length, controls);
-        }
-        void INCC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
-        {
-            engine->INCC(toAdd, start, length, carryIndex);
-        }
-        void INCS(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex)
-        {
-            engine->INCS(toAdd, start, length, overflowIndex);
-        }
-        void INCSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex)
-        {
-            engine->INCSC(toAdd, start, length, overflowIndex, carryIndex);
-        }
-        void INCSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
-        {
-            engine->INCSC(toAdd, start, length, carryIndex);
-        }
-        void DECC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
-        {
-            engine->DECC(toSub, start, length, carryIndex);
-        }
-        void DECSC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex)
-        {
-            engine->DECSC(toSub, start, length, overflowIndex, carryIndex);
-        }
-        void DECSC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
-        {
-            engine->DECSC(toSub, start, length, carryIndex);
-        }
+    void INC(bitCapInt toAdd, bitLenInt start, bitLenInt length) { engine->INC(toAdd, start, length); }
+    void CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const std::vector<bitLenInt>& controls)
+    {
+        engine->CINC(toAdd, inOutStart, length, controls);
+    }
+    void INCC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
+    {
+        engine->INCC(toAdd, start, length, carryIndex);
+    }
+    void INCS(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex)
+    {
+        engine->INCS(toAdd, start, length, overflowIndex);
+    }
+    void INCSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex)
+    {
+        engine->INCSC(toAdd, start, length, overflowIndex, carryIndex);
+    }
+    void INCSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
+    {
+        engine->INCSC(toAdd, start, length, carryIndex);
+    }
+    void DECC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
+    {
+        engine->DECC(toSub, start, length, carryIndex);
+    }
+    void DECSC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex)
+    {
+        engine->DECSC(toSub, start, length, overflowIndex, carryIndex);
+    }
+    void DECSC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
+    {
+        engine->DECSC(toSub, start, length, carryIndex);
+    }
 #if ENABLE_BCD
-        void INCBCD(bitCapInt toAdd, bitLenInt start, bitLenInt length) { engine->INCBCD(toAdd, start, length); }
-        void INCBCDC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
-        {
-            engine->INCBCDC(toAdd, start, length, carryIndex);
-        }
-        void DECBCDC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
-        {
-            engine->DECBCDC(toSub, start, length, carryIndex);
-        }
+    void INCBCD(bitCapInt toAdd, bitLenInt start, bitLenInt length) { engine->INCBCD(toAdd, start, length); }
+    void INCBCDC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
+    {
+        engine->INCBCDC(toAdd, start, length, carryIndex);
+    }
+    void DECBCDC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
+    {
+        engine->DECBCDC(toSub, start, length, carryIndex);
+    }
 #endif
-        void MUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length)
-        {
-            engine->MUL(toMul, inOutStart, carryStart, length);
-        }
-        void DIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length)
-        {
-            engine->DIV(toDiv, inOutStart, carryStart, length);
-        }
-        void MULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length)
-        {
-            engine->MULModNOut(toMul, modN, inStart, outStart, length);
-        }
-        void IMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length)
-        {
-            engine->IMULModNOut(toMul, modN, inStart, outStart, length);
-        }
-        void POWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length)
-        {
-            engine->POWModNOut(base, modN, inStart, outStart, length);
-        }
-        void CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
-            const std::vector<bitLenInt>& controls)
-        {
-            engine->CMUL(toMul, inOutStart, carryStart, length, controls);
-        }
-        void CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
-            const std::vector<bitLenInt>& controls)
-        {
-            engine->CDIV(toDiv, inOutStart, carryStart, length, controls);
-        }
-        void CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-            const std::vector<bitLenInt>& controls)
-        {
-            engine->CMULModNOut(toMul, modN, inStart, outStart, length, controls);
-        }
-        void CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-            const std::vector<bitLenInt>& controls)
-        {
-            engine->CIMULModNOut(toMul, modN, inStart, outStart, length, controls);
-        }
-        void CPOWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
-            const std::vector<bitLenInt>& controls)
-        {
-            engine->CPOWModNOut(base, modN, inStart, outStart, length, controls);
-        }
+    void MUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length)
+    {
+        engine->MUL(toMul, inOutStart, carryStart, length);
+    }
+    void DIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length)
+    {
+        engine->DIV(toDiv, inOutStart, carryStart, length);
+    }
+    void MULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length)
+    {
+        engine->MULModNOut(toMul, modN, inStart, outStart, length);
+    }
+    void IMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length)
+    {
+        engine->IMULModNOut(toMul, modN, inStart, outStart, length);
+    }
+    void POWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length)
+    {
+        engine->POWModNOut(base, modN, inStart, outStart, length);
+    }
+    void CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
+        const std::vector<bitLenInt>& controls)
+    {
+        engine->CMUL(toMul, inOutStart, carryStart, length, controls);
+    }
+    void CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
+        const std::vector<bitLenInt>& controls)
+    {
+        engine->CDIV(toDiv, inOutStart, carryStart, length, controls);
+    }
+    void CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
+        const std::vector<bitLenInt>& controls)
+    {
+        engine->CMULModNOut(toMul, modN, inStart, outStart, length, controls);
+    }
+    void CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
+        const std::vector<bitLenInt>& controls)
+    {
+        engine->CIMULModNOut(toMul, modN, inStart, outStart, length, controls);
+    }
+    void CPOWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
+        const std::vector<bitLenInt>& controls)
+    {
+        engine->CPOWModNOut(base, modN, inStart, outStart, length, controls);
+    }
 
-        bitCapInt IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
-            const unsigned char* values, bool resetValue = true)
-        {
-            return engine->IndexedLDA(indexStart, indexLength, valueStart, valueLength, values, resetValue);
-        }
-        bitCapInt IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
-            bitLenInt carryIndex, const unsigned char* values)
-        {
-            return engine->IndexedADC(indexStart, indexLength, valueStart, valueLength, carryIndex, values);
-        }
-        bitCapInt IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
-            bitLenInt carryIndex, const unsigned char* values)
-        {
-            return engine->IndexedSBC(indexStart, indexLength, valueStart, valueLength, carryIndex, values);
-        }
-        void Hash(bitLenInt start, bitLenInt length, const unsigned char* values)
-        {
-            engine->Hash(start, length, values);
-        }
+    bitCapInt IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
+        const unsigned char* values, bool resetValue = true)
+    {
+        return engine->IndexedLDA(indexStart, indexLength, valueStart, valueLength, values, resetValue);
+    }
+    bitCapInt IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
+        bitLenInt carryIndex, const unsigned char* values)
+    {
+        return engine->IndexedADC(indexStart, indexLength, valueStart, valueLength, carryIndex, values);
+    }
+    bitCapInt IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
+        bitLenInt carryIndex, const unsigned char* values)
+    {
+        return engine->IndexedSBC(indexStart, indexLength, valueStart, valueLength, carryIndex, values);
+    }
+    void Hash(bitLenInt start, bitLenInt length, const unsigned char* values) { engine->Hash(start, length, values); }
 
-        void CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length, bitLenInt flagIndex)
-        {
-            engine->CPhaseFlipIfLess(greaterPerm, start, length, flagIndex);
-        }
-        void PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length)
-        {
-            engine->PhaseFlipIfLess(greaterPerm, start, length);
-        }
+    void CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length, bitLenInt flagIndex)
+    {
+        engine->CPhaseFlipIfLess(greaterPerm, start, length, flagIndex);
+    }
+    void PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length)
+    {
+        engine->PhaseFlipIfLess(greaterPerm, start, length);
+    }
 #endif
 
-        void Swap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->Swap(qubitIndex1, qubitIndex2); }
-        void ISwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->ISwap(qubitIndex1, qubitIndex2); }
-        void IISwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->IISwap(qubitIndex1, qubitIndex2); }
-        void SqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->SqrtSwap(qubitIndex1, qubitIndex2); }
-        void ISqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->ISqrtSwap(qubitIndex1, qubitIndex2); }
-        void FSim(real1_f theta, real1_f phi, bitLenInt qubitIndex1, bitLenInt qubitIndex2)
-        {
-            engine->FSim(theta, phi, qubitIndex1, qubitIndex2);
-        }
+    void Swap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->Swap(qubitIndex1, qubitIndex2); }
+    void ISwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->ISwap(qubitIndex1, qubitIndex2); }
+    void IISwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->IISwap(qubitIndex1, qubitIndex2); }
+    void SqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->SqrtSwap(qubitIndex1, qubitIndex2); }
+    void ISqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->ISqrtSwap(qubitIndex1, qubitIndex2); }
+    void FSim(real1_f theta, real1_f phi, bitLenInt qubitIndex1, bitLenInt qubitIndex2)
+    {
+        engine->FSim(theta, phi, qubitIndex1, qubitIndex2);
+    }
 
-        real1_f Prob(bitLenInt qubitIndex) { return engine->Prob(qubitIndex); }
-        real1_f ProbAll(bitCapInt fullRegister) { return engine->ProbAll(fullRegister); }
-        real1_f ProbMask(bitCapInt mask, bitCapInt permutation) { return engine->ProbMask(mask, permutation); }
+    real1_f Prob(bitLenInt qubitIndex) { return engine->Prob(qubitIndex); }
+    real1_f ProbAll(bitCapInt fullRegister) { return engine->ProbAll(fullRegister); }
+    real1_f ProbMask(bitCapInt mask, bitCapInt permutation) { return engine->ProbMask(mask, permutation); }
 
-        real1_f SumSqrDiff(QInterfacePtr toCompare)
-        {
-            return SumSqrDiff(std::dynamic_pointer_cast<QInterfaceNoisy>(toCompare));
-        }
-        real1_f SumSqrDiff(QInterfaceNoisyPtr toCompare)
-        {
-            toCompare->SwitchModes(isGpu, isPager);
-            return engine->SumSqrDiff(toCompare->engine);
-        }
+    real1_f SumSqrDiff(QInterfacePtr toCompare)
+    {
+        return SumSqrDiff(std::dynamic_pointer_cast<QInterfaceNoisy>(toCompare));
+    }
+    real1_f SumSqrDiff(QInterfaceNoisyPtr toCompare) { return engine->SumSqrDiff(toCompare->engine); }
 
-        void UpdateRunningNorm(real1_f norm_thresh = REAL1_DEFAULT_ARG) { engine->UpdateRunningNorm(norm_thresh); }
-        void NormalizeState(
-            real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1_F)
-        {
-            engine->NormalizeState(nrm, norm_thresh, phaseArg);
-        }
+    void UpdateRunningNorm(real1_f norm_thresh = REAL1_DEFAULT_ARG) { engine->UpdateRunningNorm(norm_thresh); }
+    void NormalizeState(
+        real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1_F)
+    {
+        engine->NormalizeState(nrm, norm_thresh, phaseArg);
+    }
 
-        real1_f ExpectationBitsAll(const std::vector<bitLenInt>& bits, const bitCapInt& offset = ZERO_BCI)
-        {
-            return engine->ExpectationBitsAll(bits, offset);
-        }
+    real1_f ExpectationBitsAll(const std::vector<bitLenInt>& bits, const bitCapInt& offset = ZERO_BCI)
+    {
+        return engine->ExpectationBitsAll(bits, offset);
+    }
 
-        void Finish() { engine->Finish(); }
+    void Finish() { engine->Finish(); }
 
-        bool isFinished() { return engine->isFinished(); }
+    bool isFinished() { return engine->isFinished(); }
 
-        void Dump() { engine->Dump(); }
+    void Dump() { engine->Dump(); }
 
-        QInterfacePtr Clone()
-        {
-            QInterfaceNoisyPtr c = std::make_shared<QInterfaceNoisy>(qubitCount, ZERO_BCI, rand_generator, phaseFactor,
-                doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse, (real1_f)amplitudeFloor,
-                deviceIDs, gpuThresholdQubits, separabilityThreshold);
-            c->runningNorm = runningNorm;
-            c->SetConcurrency(GetConcurrencyLevel());
-            c->engine->CopyStateVec(engine);
-            return c;
-        }
+    QInterfacePtr Clone()
+    {
+        QInterfaceNoisyPtr c = std::make_shared<QInterfaceNoisy>(this);
+        c->engine = engine->Clone();
+        return c;
+    }
 
-        void SetDevice(int64_t dID)
-        {
-            devID = dID;
-            engine->SetDevice(dID);
-        }
+    void SetDevice(int64_t dID)
+    {
+        devID = dID;
+        engine->SetDevice(dID);
+    }
 
-        int64_t GetDevice() { return devID; }
+    int64_t GetDevice() { return engine->GetDevice(); }
 
-        bitCapIntOcl GetMaxSize() { return engine->GetMaxSize(); };
-
-    protected:
-        real1_f GetExpectation(bitLenInt valueStart, bitLenInt valueLength)
-        {
-            return engine->GetExpectation(valueStart, valueLength);
-        }
-
-        void Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const complex* mtrx, bitLenInt bitCount,
-            const bitCapIntOcl* qPowersSorted, bool doCalcNorm, real1_f norm_thresh = REAL1_DEFAULT_ARG)
-        {
-            engine->Apply2x2(offset1, offset2, mtrx, bitCount, qPowersSorted, doCalcNorm, norm_thresh);
-        }
-        void ApplyControlled2x2(const std::vector<bitLenInt>& controls, bitLenInt target, const complex* mtrx)
-        {
-            engine->ApplyControlled2x2(controls, target, mtrx);
-        }
-        void ApplyAntiControlled2x2(const std::vector<bitLenInt>& controls, bitLenInt target, const complex* mtrx)
-        {
-            engine->ApplyAntiControlled2x2(controls, target, mtrx);
-        }
-
-#if ENABLE_ALU
-        void INCDECC(bitCapInt toMod, bitLenInt inOutStart, bitLenInt length, bitLenInt carryIndex)
-        {
-            engine->INCDECC(toMod, inOutStart, length, carryIndex);
-        }
-        void INCDECSC(bitCapInt toMod, bitLenInt inOutStart, bitLenInt length, bitLenInt carryIndex)
-        {
-            engine->INCDECSC(toMod, inOutStart, length, carryIndex);
-        }
-        void INCDECSC(
-            bitCapInt toMod, bitLenInt inOutStart, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex)
-        {
-            engine->INCDECSC(toMod, inOutStart, length, overflowIndex, carryIndex);
-        }
-#if ENABLE_BCD
-        void INCDECBCDC(bitCapInt toMod, bitLenInt inOutStart, bitLenInt length, bitLenInt carryIndex)
-        {
-            engine->INCDECBCDC(toMod, inOutStart, length, carryIndex);
-        }
-#endif
-#endif
-    };
+    bitCapIntOcl GetMaxSize() { return engine->GetMaxSize(); };
+};
 } // namespace Qrack

--- a/include/qinterface_noisy.hpp
+++ b/include/qinterface_noisy.hpp
@@ -1,0 +1,466 @@
+//////////////////////////////////////////////////////////////////////////////////////
+//
+// (C) Daniel Strano and the Qrack contributors 2017-2023. All rights reserved.
+//
+// This is a multithreaded, universal quantum register simulation, allowing
+// (nonphysical) register cloning and direct measurement of probability and
+// phase, to leverage what advantages classical emulation of qubits can have.
+//
+// Licensed under the GNU Lesser General Public License V3.
+// See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
+// for details.
+#pragma once
+
+#include "qparity.hpp"
+
+#if ENABLE_ALU
+#include "qalu.hpp"
+#endif
+
+#if !ENABLE_OPENCL && !ENABLE_CUDA
+#error OpenCL or CUDA has not been enabled
+#endif
+
+#if ENABLE_OPENCL
+#define QRACK_GPU_ENGINE QINTERFACE_OPENCL
+#else
+#define QRACK_GPU_ENGINE QINTERFACE_CUDA
+#endif
+
+namespace Qrack {
+
+class QInterfaceNoisy;
+typedef std::shared_ptr<QInterfaceNoisy> QInterfaceNoisyPtr;
+
+/**
+ * A "Qrack::QInterfaceNoisy" that wraps any other QInterface with a simple noise model
+ */
+
+namespace Qrack {
+
+    class QUnit;
+    typedef std::shared_ptr<QUnit> QUnitPtr;
+
+#if ENABLE_ALU
+    class QInterfaceNoisy : public QAlu, public QParity, public QInterface {
+#else
+    class QInterfaceNoisy : public QParity, public QInterface {
+#endif
+    protected:
+        real1_f noiseParam;
+        QInterfacePtr engine;
+        std::vector<QInterfaceEngine> engines;
+
+    public:
+        QInterfaceNoisy(bitLenInt qBitCount, bitCapInt initState = ZERO_BCI, qrack_rand_gen_ptr rgp = nullptr,
+            complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,
+            bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true, bool useSparseStateVec = false,
+            real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {}, bitLenInt qubitThreshold = 0U,
+            real1_f separation_thresh = FP_NORM_EPSILON_F)
+            : QInterfaceNoisy({ QINTERFACE_TENSOR_NETWORK }, qBitCount, initState, rgp, phaseFac, doNorm,
+                  randomGlobalPhase, useHostMem, deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, devList,
+                  qubitThreshold, separation_thresh)
+            {
+                // Intentionally left blank;
+            }
+
+        QInterfaceNoisy(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState = ZERO_BCI,
+            qrack_rand_gen_ptr rgp = nullptr, complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false,
+            bool randomGlobalPhase = true, bool useHostMem = false, int64_t deviceId = -1, bool useHardwareRNG = true,
+            bool useSparseStateVec = false, real1_f norm_thresh = REAL1_EPSILON, std::vector<int64_t> devList = {},
+            bitLenInt qubitThreshold = 0U, real1_f separation_thresh = FP_NORM_EPSILON_F);
+
+        void SetNoiseLevel(real1_f lambda) { noiseParam = lambda; }
+
+        void SetQubitCount(bitLenInt qb)
+        {
+            QInterface::SetQubitCount(qb);
+            engine->SetQubitCount(qb);
+        }
+
+        bool isOpenCL() { return engine->isOpenCL(); }
+
+        void SetConcurrency(uint32_t threadCount)
+        {
+            QInterface::SetConcurrency(threadCount);
+            engine->SetConcurrency(GetConcurrencyLevel());
+        }
+
+        real1_f ProbReg(bitLenInt start, bitLenInt length, bitCapInt permutation)
+        {
+            return engine->ProbReg(start, length, permutation);
+        }
+
+        using QInterface::Compose;
+        bitLenInt Compose(QInterfaceNoisyPtr toCopy)
+        {
+            SetQubitCount(qubitCount + toCopy->qubitCount);
+            return engine->Compose(toCopy->engine);
+        }
+        bitLenInt Compose(QInterfacePtr toCopy) { return Compose(std::dynamic_pointer_cast<QInterfaceNoisy>(toCopy)); }
+        bitLenInt Compose(QInterfaceNoisyPtr toCopy, bitLenInt start)
+        {
+            SetQubitCount(qubitCount + toCopy->qubitCount);
+            return engine->Compose(toCopy->engine, start);
+        }
+        bitLenInt Compose(QInterfacePtr toCopy, bitLenInt start)
+        {
+            return Compose(std::dynamic_pointer_cast<QInterfaceNoisy>(toCopy), start);
+        }
+        bitLenInt ComposeNoClone(QInterfaceNoisyPtr toCopy)
+        {
+            SetQubitCount(qubitCount + toCopy->qubitCount);
+            return engine->ComposeNoClone(toCopy->engine);
+        }
+        bitLenInt ComposeNoClone(QInterfacePtr toCopy)
+        {
+            return ComposeNoClone(std::dynamic_pointer_cast<QInterfaceNoisy>(toCopy));
+        }
+        using QInterface::Decompose;
+        void Decompose(bitLenInt start, QInterfacePtr dest)
+        {
+            Decompose(start, std::dynamic_pointer_cast<QInterfaceNoisy>(dest));
+        }
+        bool TryDecompose(bitLenInt start, QInterfacePtr dest, real1_f error_tol = TRYDECOMPOSE_EPSILON)
+        {
+            return TryDecompose(start, std::dynamic_pointer_cast<QInterfaceNoisy>(dest), error_tol);
+        }
+        void Decompose(bitLenInt start, QInterfaceNoisyPtr dest)
+        {
+            engine->Decompose(start, dest->engine);
+            SetQubitCount(qubitCount - dest->GetQubitCount());
+        }
+        void Dispose(bitLenInt start, bitLenInt length)
+        {
+            engine->Dispose(start, length);
+            SetQubitCount(qubitCount - length);
+        }
+        void Dispose(bitLenInt start, bitLenInt length, bitCapInt disposedPerm)
+        {
+            engine->Dispose(start, length, disposedPerm);
+            SetQubitCount(qubitCount - length);
+        }
+
+        using QInterface::Allocate;
+        bitLenInt Allocate(bitLenInt start, bitLenInt length)
+        {
+            if (!length) {
+                return start;
+            }
+
+            QInterfaceNoisyPtr nQubits = std::make_shared<QInterfaceNoisy>(length, ZERO_BCI, rand_generator,
+                phaseFactor, doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse,
+                (real1_f)amplitudeFloor, deviceIDs, gpuThresholdQubits, separabilityThreshold);
+            nQubits->SetConcurrency(GetConcurrencyLevel());
+
+            return Compose(nQubits, start);
+        }
+
+        bool TryDecompose(bitLenInt start, QInterfaceNoisyPtr dest, real1_f error_tol = TRYDECOMPOSE_EPSILON)
+        {
+            const bitLenInt nQubitCount = qubitCount - dest->GetQubitCount();
+            const bool result = engine->TryDecompose(start, dest->engine, error_tol);
+            if (result) {
+                SetQubitCount(nQubitCount);
+            }
+            return result;
+        }
+
+        void SetQuantumState(const complex* inputState) { engine->SetQuantumState(inputState); }
+        void GetQuantumState(complex* outputState) { engine->GetQuantumState(outputState); }
+        void GetProbs(real1* outputProbs) { engine->GetProbs(outputProbs); }
+        complex GetAmplitude(bitCapInt perm) { return engine->GetAmplitude(perm); }
+        void SetAmplitude(bitCapInt perm, complex amp) { engine->SetAmplitude(perm, amp); }
+        void SetPermutation(bitCapInt perm, complex phaseFac = CMPLX_DEFAULT_ARG)
+        {
+            engine->SetPermutation(perm, phaseFac);
+        }
+
+        void Mtrx(const complex* mtrx, bitLenInt qubitIndex) { engine->Mtrx(mtrx, qubitIndex); }
+        void Phase(complex topLeft, complex bottomRight, bitLenInt qubitIndex)
+        {
+            engine->Phase(topLeft, bottomRight, qubitIndex);
+        }
+        void Invert(complex topRight, complex bottomLeft, bitLenInt qubitIndex)
+        {
+            engine->Invert(topRight, bottomLeft, qubitIndex);
+        }
+        void MCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
+        {
+            engine->MCMtrx(controls, mtrx, target);
+        }
+        void MACMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
+        {
+            engine->MACMtrx(controls, mtrx, target);
+        }
+
+        using QInterface::UniformlyControlledSingleBit;
+        void UniformlyControlledSingleBit(const std::vector<bitLenInt>& controls, bitLenInt qubitIndex,
+            const complex* mtrxs, const std::vector<bitCapInt> mtrxSkipPowers, bitCapInt mtrxSkipValueMask)
+        {
+            engine->UniformlyControlledSingleBit(controls, qubitIndex, mtrxs, mtrxSkipPowers, mtrxSkipValueMask);
+        }
+
+        void XMask(bitCapInt mask) { engine->XMask(mask); }
+        void PhaseParity(real1_f radians, bitCapInt mask) { engine->PhaseParity(radians, mask); }
+
+        real1_f CProb(bitLenInt control, bitLenInt target) { return engine->CProb(control, target); }
+        real1_f ACProb(bitLenInt control, bitLenInt target) { return engine->ACProb(control, target); }
+
+        void CSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
+        {
+            engine->CSwap(controls, qubit1, qubit2);
+        }
+        void AntiCSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
+        {
+            engine->AntiCSwap(controls, qubit1, qubit2);
+        }
+        void CSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
+        {
+            engine->CSqrtSwap(controls, qubit1, qubit2);
+        }
+        void AntiCSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
+        {
+            engine->AntiCSqrtSwap(controls, qubit1, qubit2);
+        }
+        void CISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
+        {
+            engine->CISqrtSwap(controls, qubit1, qubit2);
+        }
+        void AntiCISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
+        {
+            engine->AntiCISqrtSwap(controls, qubit1, qubit2);
+        }
+
+        bool ForceM(bitLenInt qubit, bool result, bool doForce = true, bool doApply = true)
+        {
+            return engine->ForceM(qubit, result, doForce, doApply);
+        }
+
+#if ENABLE_ALU
+        void INC(bitCapInt toAdd, bitLenInt start, bitLenInt length) { engine->INC(toAdd, start, length); }
+        void CINC(bitCapInt toAdd, bitLenInt inOutStart, bitLenInt length, const std::vector<bitLenInt>& controls)
+        {
+            engine->CINC(toAdd, inOutStart, length, controls);
+        }
+        void INCC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
+        {
+            engine->INCC(toAdd, start, length, carryIndex);
+        }
+        void INCS(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex)
+        {
+            engine->INCS(toAdd, start, length, overflowIndex);
+        }
+        void INCSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex)
+        {
+            engine->INCSC(toAdd, start, length, overflowIndex, carryIndex);
+        }
+        void INCSC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
+        {
+            engine->INCSC(toAdd, start, length, carryIndex);
+        }
+        void DECC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
+        {
+            engine->DECC(toSub, start, length, carryIndex);
+        }
+        void DECSC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex)
+        {
+            engine->DECSC(toSub, start, length, overflowIndex, carryIndex);
+        }
+        void DECSC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
+        {
+            engine->DECSC(toSub, start, length, carryIndex);
+        }
+#if ENABLE_BCD
+        void INCBCD(bitCapInt toAdd, bitLenInt start, bitLenInt length) { engine->INCBCD(toAdd, start, length); }
+        void INCBCDC(bitCapInt toAdd, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
+        {
+            engine->INCBCDC(toAdd, start, length, carryIndex);
+        }
+        void DECBCDC(bitCapInt toSub, bitLenInt start, bitLenInt length, bitLenInt carryIndex)
+        {
+            engine->DECBCDC(toSub, start, length, carryIndex);
+        }
+#endif
+        void MUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length)
+        {
+            engine->MUL(toMul, inOutStart, carryStart, length);
+        }
+        void DIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length)
+        {
+            engine->DIV(toDiv, inOutStart, carryStart, length);
+        }
+        void MULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length)
+        {
+            engine->MULModNOut(toMul, modN, inStart, outStart, length);
+        }
+        void IMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length)
+        {
+            engine->IMULModNOut(toMul, modN, inStart, outStart, length);
+        }
+        void POWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length)
+        {
+            engine->POWModNOut(base, modN, inStart, outStart, length);
+        }
+        void CMUL(bitCapInt toMul, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
+            const std::vector<bitLenInt>& controls)
+        {
+            engine->CMUL(toMul, inOutStart, carryStart, length, controls);
+        }
+        void CDIV(bitCapInt toDiv, bitLenInt inOutStart, bitLenInt carryStart, bitLenInt length,
+            const std::vector<bitLenInt>& controls)
+        {
+            engine->CDIV(toDiv, inOutStart, carryStart, length, controls);
+        }
+        void CMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
+            const std::vector<bitLenInt>& controls)
+        {
+            engine->CMULModNOut(toMul, modN, inStart, outStart, length, controls);
+        }
+        void CIMULModNOut(bitCapInt toMul, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
+            const std::vector<bitLenInt>& controls)
+        {
+            engine->CIMULModNOut(toMul, modN, inStart, outStart, length, controls);
+        }
+        void CPOWModNOut(bitCapInt base, bitCapInt modN, bitLenInt inStart, bitLenInt outStart, bitLenInt length,
+            const std::vector<bitLenInt>& controls)
+        {
+            engine->CPOWModNOut(base, modN, inStart, outStart, length, controls);
+        }
+
+        bitCapInt IndexedLDA(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
+            const unsigned char* values, bool resetValue = true)
+        {
+            return engine->IndexedLDA(indexStart, indexLength, valueStart, valueLength, values, resetValue);
+        }
+        bitCapInt IndexedADC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
+            bitLenInt carryIndex, const unsigned char* values)
+        {
+            return engine->IndexedADC(indexStart, indexLength, valueStart, valueLength, carryIndex, values);
+        }
+        bitCapInt IndexedSBC(bitLenInt indexStart, bitLenInt indexLength, bitLenInt valueStart, bitLenInt valueLength,
+            bitLenInt carryIndex, const unsigned char* values)
+        {
+            return engine->IndexedSBC(indexStart, indexLength, valueStart, valueLength, carryIndex, values);
+        }
+        void Hash(bitLenInt start, bitLenInt length, const unsigned char* values)
+        {
+            engine->Hash(start, length, values);
+        }
+
+        void CPhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length, bitLenInt flagIndex)
+        {
+            engine->CPhaseFlipIfLess(greaterPerm, start, length, flagIndex);
+        }
+        void PhaseFlipIfLess(bitCapInt greaterPerm, bitLenInt start, bitLenInt length)
+        {
+            engine->PhaseFlipIfLess(greaterPerm, start, length);
+        }
+#endif
+
+        void Swap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->Swap(qubitIndex1, qubitIndex2); }
+        void ISwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->ISwap(qubitIndex1, qubitIndex2); }
+        void IISwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->IISwap(qubitIndex1, qubitIndex2); }
+        void SqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->SqrtSwap(qubitIndex1, qubitIndex2); }
+        void ISqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->ISqrtSwap(qubitIndex1, qubitIndex2); }
+        void FSim(real1_f theta, real1_f phi, bitLenInt qubitIndex1, bitLenInt qubitIndex2)
+        {
+            engine->FSim(theta, phi, qubitIndex1, qubitIndex2);
+        }
+
+        real1_f Prob(bitLenInt qubitIndex) { return engine->Prob(qubitIndex); }
+        real1_f ProbAll(bitCapInt fullRegister) { return engine->ProbAll(fullRegister); }
+        real1_f ProbMask(bitCapInt mask, bitCapInt permutation) { return engine->ProbMask(mask, permutation); }
+
+        real1_f SumSqrDiff(QInterfacePtr toCompare)
+        {
+            return SumSqrDiff(std::dynamic_pointer_cast<QInterfaceNoisy>(toCompare));
+        }
+        real1_f SumSqrDiff(QInterfaceNoisyPtr toCompare)
+        {
+            toCompare->SwitchModes(isGpu, isPager);
+            return engine->SumSqrDiff(toCompare->engine);
+        }
+
+        void UpdateRunningNorm(real1_f norm_thresh = REAL1_DEFAULT_ARG) { engine->UpdateRunningNorm(norm_thresh); }
+        void NormalizeState(
+            real1_f nrm = REAL1_DEFAULT_ARG, real1_f norm_thresh = REAL1_DEFAULT_ARG, real1_f phaseArg = ZERO_R1_F)
+        {
+            engine->NormalizeState(nrm, norm_thresh, phaseArg);
+        }
+
+        real1_f ExpectationBitsAll(const std::vector<bitLenInt>& bits, const bitCapInt& offset = ZERO_BCI)
+        {
+            return engine->ExpectationBitsAll(bits, offset);
+        }
+
+        void Finish() { engine->Finish(); }
+
+        bool isFinished() { return engine->isFinished(); }
+
+        void Dump() { engine->Dump(); }
+
+        QInterfacePtr Clone()
+        {
+            QInterfaceNoisyPtr c = std::make_shared<QInterfaceNoisy>(qubitCount, ZERO_BCI, rand_generator, phaseFactor,
+                doNormalize, randGlobalPhase, useHostRam, devID, useRDRAND, isSparse, (real1_f)amplitudeFloor,
+                deviceIDs, gpuThresholdQubits, separabilityThreshold);
+            c->runningNorm = runningNorm;
+            c->SetConcurrency(GetConcurrencyLevel());
+            c->engine->CopyStateVec(engine);
+            return c;
+        }
+
+        void SetDevice(int64_t dID)
+        {
+            devID = dID;
+            engine->SetDevice(dID);
+        }
+
+        int64_t GetDevice() { return devID; }
+
+        bitCapIntOcl GetMaxSize() { return engine->GetMaxSize(); };
+
+    protected:
+        real1_f GetExpectation(bitLenInt valueStart, bitLenInt valueLength)
+        {
+            return engine->GetExpectation(valueStart, valueLength);
+        }
+
+        void Apply2x2(bitCapIntOcl offset1, bitCapIntOcl offset2, const complex* mtrx, bitLenInt bitCount,
+            const bitCapIntOcl* qPowersSorted, bool doCalcNorm, real1_f norm_thresh = REAL1_DEFAULT_ARG)
+        {
+            engine->Apply2x2(offset1, offset2, mtrx, bitCount, qPowersSorted, doCalcNorm, norm_thresh);
+        }
+        void ApplyControlled2x2(const std::vector<bitLenInt>& controls, bitLenInt target, const complex* mtrx)
+        {
+            engine->ApplyControlled2x2(controls, target, mtrx);
+        }
+        void ApplyAntiControlled2x2(const std::vector<bitLenInt>& controls, bitLenInt target, const complex* mtrx)
+        {
+            engine->ApplyAntiControlled2x2(controls, target, mtrx);
+        }
+
+#if ENABLE_ALU
+        void INCDECC(bitCapInt toMod, bitLenInt inOutStart, bitLenInt length, bitLenInt carryIndex)
+        {
+            engine->INCDECC(toMod, inOutStart, length, carryIndex);
+        }
+        void INCDECSC(bitCapInt toMod, bitLenInt inOutStart, bitLenInt length, bitLenInt carryIndex)
+        {
+            engine->INCDECSC(toMod, inOutStart, length, carryIndex);
+        }
+        void INCDECSC(
+            bitCapInt toMod, bitLenInt inOutStart, bitLenInt length, bitLenInt overflowIndex, bitLenInt carryIndex)
+        {
+            engine->INCDECSC(toMod, inOutStart, length, overflowIndex, carryIndex);
+        }
+#if ENABLE_BCD
+        void INCDECBCDC(bitCapInt toMod, bitLenInt inOutStart, bitLenInt length, bitLenInt carryIndex)
+        {
+            engine->INCDECBCDC(toMod, inOutStart, length, carryIndex);
+        }
+#endif
+#endif
+    };
+} // namespace Qrack

--- a/include/qinterface_noisy.hpp
+++ b/include/qinterface_noisy.hpp
@@ -170,22 +170,30 @@ public:
         engine->SetPermutation(perm, phaseFac);
     }
 
-    void Mtrx(const complex* mtrx, bitLenInt qubitIndex) { engine->Mtrx(mtrx, qubitIndex); }
+    void Mtrx(const complex* mtrx, bitLenInt qubitIndex)
+    {
+        engine->Mtrx(mtrx, qubitIndex);
+        Apply1QbNoise(qubitIndex);
+    }
     void Phase(complex topLeft, complex bottomRight, bitLenInt qubitIndex)
     {
         engine->Phase(topLeft, bottomRight, qubitIndex);
+        Apply1QbNoise(qubitIndex);
     }
     void Invert(complex topRight, complex bottomLeft, bitLenInt qubitIndex)
     {
         engine->Invert(topRight, bottomLeft, qubitIndex);
+        Apply1QbNoise(qubitIndex);
     }
     void MCMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
     {
         engine->MCMtrx(controls, mtrx, target);
+        Apply1QbNoise(target);
     }
     void MACMtrx(const std::vector<bitLenInt>& controls, const complex* mtrx, bitLenInt target)
     {
         engine->MACMtrx(controls, mtrx, target);
+        Apply1QbNoise(target);
     }
 
     using QInterface::UniformlyControlledSingleBit;
@@ -193,10 +201,32 @@ public:
         const complex* mtrxs, const std::vector<bitCapInt> mtrxSkipPowers, bitCapInt mtrxSkipValueMask)
     {
         engine->UniformlyControlledSingleBit(controls, qubitIndex, mtrxs, mtrxSkipPowers, mtrxSkipValueMask);
+        Apply1QbNoise(qubitIndex);
+        for (const bitLenInt& control : controls) {
+            Apply1QbNoise(control);
+        }
     }
 
-    void XMask(bitCapInt mask) { engine->XMask(mask); }
-    void PhaseParity(real1_f radians, bitCapInt mask) { engine->PhaseParity(radians, mask); }
+    void XMask(bitCapInt mask)
+    {
+        engine->XMask(mask);
+        bitCapInt v = mask;
+        while (bi_compare_0(mask) != 0) {
+            v = v & (v - ONE_BCI);
+            Apply1QbNoise(log2(mask ^ v));
+            mask = v;
+        }
+    }
+    void PhaseParity(real1_f radians, bitCapInt mask)
+    {
+        engine->PhaseParity(radians, mask);
+        bitCapInt v = mask;
+        while (bi_compare_0(mask) != 0) {
+            v = v & (v - ONE_BCI);
+            Apply1QbNoise(log2(mask ^ v));
+            mask = v;
+        }
+    }
 
     real1_f CProb(bitLenInt control, bitLenInt target) { return engine->CProb(control, target); }
     real1_f ACProb(bitLenInt control, bitLenInt target) { return engine->ACProb(control, target); }
@@ -204,26 +234,56 @@ public:
     void CSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
     {
         engine->CSwap(controls, qubit1, qubit2);
+        Apply1QbNoise(qubit1);
+        Apply1QbNoise(qubit2);
+        for (const bitLenInt& control : controls) {
+            Apply1QbNoise(control);
+        }
     }
     void AntiCSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
     {
         engine->AntiCSwap(controls, qubit1, qubit2);
+        Apply1QbNoise(qubit1);
+        Apply1QbNoise(qubit2);
+        for (const bitLenInt& control : controls) {
+            Apply1QbNoise(control);
+        }
     }
     void CSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
     {
         engine->CSqrtSwap(controls, qubit1, qubit2);
+        Apply1QbNoise(qubit1);
+        Apply1QbNoise(qubit2);
+        for (const bitLenInt& control : controls) {
+            Apply1QbNoise(control);
+        }
     }
     void AntiCSqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
     {
         engine->AntiCSqrtSwap(controls, qubit1, qubit2);
+        Apply1QbNoise(qubit1);
+        Apply1QbNoise(qubit2);
+        for (const bitLenInt& control : controls) {
+            Apply1QbNoise(control);
+        }
     }
     void CISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
     {
         engine->CISqrtSwap(controls, qubit1, qubit2);
+        Apply1QbNoise(qubit1);
+        Apply1QbNoise(qubit2);
+        for (const bitLenInt& control : controls) {
+            Apply1QbNoise(control);
+        }
     }
     void AntiCISqrtSwap(const std::vector<bitLenInt>& controls, bitLenInt qubit1, bitLenInt qubit2)
     {
         engine->AntiCISqrtSwap(controls, qubit1, qubit2);
+        Apply1QbNoise(qubit1);
+        Apply1QbNoise(qubit2);
+        for (const bitLenInt& control : controls) {
+            Apply1QbNoise(control);
+        }
     }
 
     bool ForceM(bitLenInt qubit, bool result, bool doForce = true, bool doApply = true)
@@ -231,14 +291,41 @@ public:
         return engine->ForceM(qubit, result, doForce, doApply);
     }
 
-    void Swap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->Swap(qubitIndex1, qubitIndex2); }
-    void ISwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->ISwap(qubitIndex1, qubitIndex2); }
-    void IISwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->IISwap(qubitIndex1, qubitIndex2); }
-    void SqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->SqrtSwap(qubitIndex1, qubitIndex2); }
-    void ISqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2) { engine->ISqrtSwap(qubitIndex1, qubitIndex2); }
+    void Swap(bitLenInt qubitIndex1, bitLenInt qubitIndex2)
+    {
+        engine->Swap(qubitIndex1, qubitIndex2);
+        Apply1QbNoise(qubitIndex1);
+        Apply1QbNoise(qubitIndex2);
+    }
+    void ISwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2)
+    {
+        engine->ISwap(qubitIndex1, qubitIndex2);
+        Apply1QbNoise(qubitIndex1);
+        Apply1QbNoise(qubitIndex2);
+    }
+    void IISwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2)
+    {
+        engine->IISwap(qubitIndex1, qubitIndex2);
+        Apply1QbNoise(qubitIndex1);
+        Apply1QbNoise(qubitIndex2);
+    }
+    void SqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2)
+    {
+        engine->SqrtSwap(qubitIndex1, qubitIndex2);
+        Apply1QbNoise(qubitIndex1);
+        Apply1QbNoise(qubitIndex2);
+    }
+    void ISqrtSwap(bitLenInt qubitIndex1, bitLenInt qubitIndex2)
+    {
+        engine->ISqrtSwap(qubitIndex1, qubitIndex2);
+        Apply1QbNoise(qubitIndex1);
+        Apply1QbNoise(qubitIndex2);
+    }
     void FSim(real1_f theta, real1_f phi, bitLenInt qubitIndex1, bitLenInt qubitIndex2)
     {
         engine->FSim(theta, phi, qubitIndex1, qubitIndex2);
+        Apply1QbNoise(qubitIndex1);
+        Apply1QbNoise(qubitIndex2);
     }
 
     real1_f Prob(bitLenInt qubitIndex) { return engine->Prob(qubitIndex); }
@@ -269,10 +356,7 @@ public:
 
     void Dump() { engine->Dump(); }
 
-    QInterfacePtr Clone()
-    {
-        return std::make_shared<QInterfaceNoisy>(this);
-    }
+    QInterfacePtr Clone() { return std::make_shared<QInterfaceNoisy>(this); }
 
     void SetDevice(int64_t dID) { engine->SetDevice(dID); }
 

--- a/include/qinterface_noisy.hpp
+++ b/include/qinterface_noisy.hpp
@@ -25,6 +25,7 @@ typedef std::shared_ptr<QInterfaceNoisy> QInterfaceNoisyPtr;
  */
 class QInterfaceNoisy : public QInterface {
 protected:
+    double logFidelity;
     real1_f noiseParam;
     QInterfacePtr engine;
     std::vector<QInterfaceEngine> engines;
@@ -38,6 +39,11 @@ protected:
         }
 #endif
         engine->DepolarizingChannelWeak1Qb(qb, n);
+        if ((n + FP_NORM_EPSILON) >= ONE_R1_F) {
+            logFidelity = -1 * std::numeric_limits<float>::infinity();
+        } else {
+            logFidelity += (double)log(ONE_R1_F - n);
+        }
     }
 
 public:
@@ -68,6 +74,9 @@ public:
     }
 
     void SetNoiseLevel(real1_f lambda) { noiseParam = lambda; }
+
+    double GetUnitaryFidelity() { return (double)exp(logFidelity); }
+    void ResetUnitaryFidelity() { logFidelity = 0.0; }
 
     void SetQubitCount(bitLenInt qb)
     {

--- a/include/qinterface_noisy.hpp
+++ b/include/qinterface_noisy.hpp
@@ -29,6 +29,17 @@ protected:
     QInterfacePtr engine;
     std::vector<QInterfaceEngine> engines;
 
+    void Apply1QbNoise(bitLenInt qb)
+    {
+        real1_f n = noiseParam;
+#if ENABLE_ENV_VARS
+        if (getenv("QRACK_GATE_DEPOLARIZATION")) {
+            n = (real1_f)std::stof(std::string(getenv("QRACK_GATE_DEPOLARIZATION")));
+        }
+#endif
+        engine->DepolarizingChannelWeak1Qb(qb, n);
+    }
+
 public:
     QInterfaceNoisy(bitLenInt qBitCount, bitCapInt initState = ZERO_BCI, qrack_rand_gen_ptr rgp = nullptr,
         complex phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,

--- a/include/qtensornetwork.hpp
+++ b/include/qtensornetwork.hpp
@@ -448,9 +448,10 @@ public:
         }
 
         // "lambda" is the overall depolarization strength.
-        // We think of this as the Euclidean norm of 3 equal,
-        // probabilistic Pauli channels for Z, X, and Y.
-        lambda = sqrt((lambda * lambda) / 3);
+        // ChatGPT (custom GPT "Elara") reasons that
+        // \epsilon(p) = (1 - p) * \rho + (p / 3) * (X \rho X + Y \rho Y + Z \rho Z),
+        // so we use lambda / 3 for 3 checks.
+        lambda = lambda / 3;
         if (Rand() < lambda) {
             Z(qubit);
         }

--- a/include/wasm_api.hpp
+++ b/include/wasm_api.hpp
@@ -489,6 +489,10 @@ void SetReactiveSeparate(quid sid, bool irs);
  * Turn off/on "T-injection" feature (for "near-Clifford" simulation with RZ gates)
  */
 void SetTInjection(quid sid, bool iti);
+/**
+ * Set noise parameter (for QInterfaceNoisy)
+ */
+void SetNoiseParameter(quid sid, double np);
 
 /**
  * Initialize a "quantum neuron" that takes a list of qubit "controls" for input and acts on a single "target" output

--- a/include/wasm_api.hpp
+++ b/include/wasm_api.hpp
@@ -83,7 +83,7 @@ struct QubitPauliBasis {
  * "OpenCL" (TURN OFF IN SERIAL BUILD) - use OpenCL acceleration (in general) hp - "Host pointer" (TURN OFF IN SERIAL
  * BUILD) - allocate OpenCL state vectors on "host" instead of "device" (useful for certain accelerators, like Intel HD)
  */
-quid init_count_type(bitLenInt q, bool tn, bool md, bool sd, bool sh, bool bdt, bool pg, bool hy, bool oc, bool hp);
+quid init_count_type(bitLenInt q, bool tn, bool md, bool sd, bool sh, bool bdt, bool pg, bool nw, bool hy, bool oc, bool hp);
 
 // Utility
 

--- a/include/wasm_api.hpp
+++ b/include/wasm_api.hpp
@@ -83,7 +83,8 @@ struct QubitPauliBasis {
  * "OpenCL" (TURN OFF IN SERIAL BUILD) - use OpenCL acceleration (in general) hp - "Host pointer" (TURN OFF IN SERIAL
  * BUILD) - allocate OpenCL state vectors on "host" instead of "device" (useful for certain accelerators, like Intel HD)
  */
-quid init_count_type(bitLenInt q, bool tn, bool md, bool sd, bool sh, bool bdt, bool pg, bool nw, bool hy, bool oc, bool hp);
+quid init_count_type(
+    bitLenInt q, bool tn, bool md, bool sd, bool sh, bool bdt, bool pg, bool nw, bool hy, bool oc, bool hp);
 
 // Utility
 

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -600,7 +600,7 @@ MICROSOFT_QUANTUM_DECL int get_error(_In_ uintq sid)
  * (External API) Initialize a simulator ID with "q" qubits and explicit layer options on/off
  */
 MICROSOFT_QUANTUM_DECL uintq init_count_type(_In_ uintq q, _In_ bool tn, _In_ bool md, _In_ bool sd, _In_ bool sh,
-    _In_ bool bdt, _In_ bool pg, _In_ bool zxf, _In_ bool hy, _In_ bool oc, _In_ bool hp)
+    _In_ bool bdt, _In_ bool pg, _In_ bool nw, _In_ bool hy, _In_ bool oc, _In_ bool hp)
 {
     META_LOCK_GUARD()
 
@@ -657,6 +657,10 @@ MICROSOFT_QUANTUM_DECL uintq init_count_type(_In_ uintq q, _In_ bool tn, _In_ bo
 
     if (tn) {
         simulatorType.push_back(QINTERFACE_TENSOR_NETWORK);
+    }
+
+    if (nw) {
+        simulatorType.push_back(QINTERFACE_NOISY);
     }
 
     // (...then reverse:)

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -3323,6 +3323,17 @@ MICROSOFT_QUANTUM_DECL void SetTInjection(_In_ uintq sid, _In_ bool irs)
     }
 }
 
+MICROSOFT_QUANTUM_DECL void SetNoiseParameter(_In_ uintq sid, _In_ double np)
+{
+    SIMULATOR_LOCK_GUARD_VOID(sid)
+    try {
+        simulator->SetNoiseParameter((real1_f)np);
+    } catch (const std::exception& ex) {
+        simulatorErrors[sid] = 1;
+        std::cout << ex.what() << std::endl;
+    }
+}
+
 #if !(FPPOW < 6 && !defined(ENABLE_COMPLEX_X2))
 /**
  * (External API) Simulate a Hamiltonian

--- a/src/qinterface_noisy.cpp
+++ b/src/qinterface_noisy.cpp
@@ -18,7 +18,7 @@ QInterfaceNoisy::QInterfaceNoisy(std::vector<QInterfaceEngine> eng, bitLenInt qB
     bitLenInt qubitThreshold, real1_f sep_thresh)
     : QInterface(qBitCount, rgp, doNorm, useHardwareRNG, randomGlobalPhase, norm_thresh)
     , logFidelity(0.0)
-    , noiseParam(ONE_R1_F / 10)
+    , noiseParam(ONE_R1_F / 100)
     , engines(eng)
 {
     engine = std::dynamic_pointer_cast<QEngine>(

--- a/src/qinterface_noisy.cpp
+++ b/src/qinterface_noisy.cpp
@@ -21,7 +21,7 @@ QInterfaceNoisy::QInterfaceNoisy(std::vector<QInterfaceEngine> eng, bitLenInt qB
     , engines(eng)
 {
     engine = std::dynamic_pointer_cast<QEngine>(
-        CreateQuantumInterface(engines, qBitCount, initState, rgp, phaseFac, doNorm, randGlobalPhase, useHostRam,
+        CreateQuantumInterface(engines, qBitCount, initState, rgp, phaseFac, doNorm, randGlobalPhase, useHostMem,
             deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold, sep_thresh));
 }
 } // namespace Qrack

--- a/src/qinterface_noisy.cpp
+++ b/src/qinterface_noisy.cpp
@@ -1,0 +1,27 @@
+//////////////////////////////////////////////////////////////////////////////////////
+//
+// (C) Daniel Strano and the Qrack contributors 2017-2023. All rights reserved.
+//
+// QPager breaks a QEngine instance into pages of contiguous amplitudes.
+//
+// Licensed under the GNU Lesser General Public License V3.
+// See LICENSE.md in the project root or https://www.gnu.org/licenses/lgpl-3.0.en.html
+// for details.
+
+#include "qfactory.hpp"
+
+namespace Qrack {
+
+QInterfaceNoisy::QInterfaceNoisy(std::vector<QInterfaceEngine> eng, bitLenInt qBitCount, bitCapInt initState,
+    qrack_rand_gen_ptr rgp, complex phaseFac, bool doNorm, bool randomGlobalPhase, bool useHostMem, int64_t deviceId,
+    bool useHardwareRNG, bool useSparseStateVec, real1_f norm_thresh, std::vector<int64_t> devList,
+    bitLenInt qubitThreshold, real1_f sep_thresh)
+    : QInterface(qBitCount, rgp, doNorm, useHardwareRNG, randomGlobalPhase, norm_thresh)
+    , noiseParam(ONE_R1_F / 10)
+    , engines(eng)
+{
+    engine = std::dynamic_pointer_cast<QEngine>(
+        CreateQuantumInterface(engines, qBitCount, initState, rgp, phaseFac, doNorm, randGlobalPhase, useHostRam,
+            deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold, sep_thresh));
+}
+} // namespace Qrack

--- a/src/qinterface_noisy.cpp
+++ b/src/qinterface_noisy.cpp
@@ -17,6 +17,7 @@ QInterfaceNoisy::QInterfaceNoisy(std::vector<QInterfaceEngine> eng, bitLenInt qB
     bool useHardwareRNG, bool useSparseStateVec, real1_f norm_thresh, std::vector<int64_t> devList,
     bitLenInt qubitThreshold, real1_f sep_thresh)
     : QInterface(qBitCount, rgp, doNorm, useHardwareRNG, randomGlobalPhase, norm_thresh)
+    , logFidelity(0.0)
     , noiseParam(ONE_R1_F / 10)
     , engines(eng)
 {

--- a/src/qinterface_noisy.cpp
+++ b/src/qinterface_noisy.cpp
@@ -21,8 +21,7 @@ QInterfaceNoisy::QInterfaceNoisy(std::vector<QInterfaceEngine> eng, bitLenInt qB
     , noiseParam(ONE_R1_F / 100)
     , engines(eng)
 {
-    engine = std::dynamic_pointer_cast<QEngine>(
-        CreateQuantumInterface(engines, qBitCount, initState, rgp, phaseFac, doNorm, randGlobalPhase, useHostMem,
-            deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold, sep_thresh));
+    engine = CreateQuantumInterface(engines, qBitCount, initState, rgp, phaseFac, doNorm, randGlobalPhase, useHostMem,
+        deviceId, useHardwareRNG, useSparseStateVec, norm_thresh, devList, qubitThreshold, sep_thresh);
 }
 } // namespace Qrack

--- a/src/wasm_api.cpp
+++ b/src/wasm_api.cpp
@@ -535,7 +535,8 @@ MapArithmeticResult2 MapArithmetic3(QInterfacePtr simulator, std::vector<bitLenI
 /**
  * (External API) Initialize a simulator ID with "q" qubits and explicit layer options on/off
  */
-quid init_count_type(bitLenInt q, bool tn, bool md, bool sd, bool sh, bool bdt, bool pg, bool nw, bool hy, bool oc, bool hp)
+quid init_count_type(
+    bitLenInt q, bool tn, bool md, bool sd, bool sh, bool bdt, bool pg, bool nw, bool hy, bool oc, bool hp)
 {
     META_LOCK_GUARD()
 

--- a/src/wasm_api.cpp
+++ b/src/wasm_api.cpp
@@ -2387,6 +2387,12 @@ void SetTInjection(quid sid, bool irs)
     simulator->SetTInjection(irs);
 }
 
+void SetNoiseParameter(quid sid, double np)
+{
+    SIMULATOR_LOCK_GUARD_VOID(sid)
+    simulator->SetNoiseParameter((real1_f)np);
+}
+
 quid init_qneuron(quid sid, std::vector<bitLenInt> c, bitLenInt q, QNeuronActivationFn f, real1_f a, real1_f tol)
 {
     META_LOCK_GUARD()

--- a/src/wasm_api.cpp
+++ b/src/wasm_api.cpp
@@ -535,7 +535,7 @@ MapArithmeticResult2 MapArithmetic3(QInterfacePtr simulator, std::vector<bitLenI
 /**
  * (External API) Initialize a simulator ID with "q" qubits and explicit layer options on/off
  */
-quid init_count_type(bitLenInt q, bool tn, bool md, bool sd, bool sh, bool bdt, bool pg, bool hy, bool oc, bool hp)
+quid init_count_type(bitLenInt q, bool tn, bool md, bool sd, bool sh, bool bdt, bool pg, bool nw, bool hy, bool oc, bool hp)
 {
     META_LOCK_GUARD()
 
@@ -592,6 +592,10 @@ quid init_count_type(bitLenInt q, bool tn, bool md, bool sd, bool sh, bool bdt, 
 
     if (tn) {
         simulatorType.push_back(QINTERFACE_TENSOR_NETWORK);
+    }
+
+    if (nw) {
+        simulatorType.push_back(QINTERFACE_NOISY);
     }
 
     // (...then reverse:)


### PR DESCRIPTION
This adds a simulation layer with support for a very basic noise model: every gate applies single-qubit depolarizing noise on each qubit involved, respectively, based upon a noise parameter that can be set in code or by environment variable, between each single gate.